### PR TITLE
[Feat] 툴 세부정보 조회 API

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/community/dto/response/BoardRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/dto/response/BoardRes.java
@@ -4,6 +4,8 @@ import com.daruda.darudaserver.domain.community.entity.Board;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AccessLevel;
 import lombok.Builder;
+
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -16,7 +18,7 @@ public record BoardRes(
         String content,
         List<String> images,
         @JsonFormat(shape=JsonFormat.Shape.STRING,pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
-        LocalDateTime updateDate
+        Timestamp updatedAt
 ) {
     public static BoardRes of(final Board board,final List<String> images){
         return BoardRes.builder()
@@ -25,7 +27,7 @@ public record BoardRes(
                 .title(board.getTitle())
                 .content(board.getContent())
                 .images(images)
-                .updateDate(board.getUpdatedAt())
+                .updatedAt(board.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
@@ -1,8 +1,17 @@
 package com.daruda.darudaserver.domain.tool.controller;
 
+import com.daruda.darudaserver.domain.tool.dto.res.PlanRes;
+import com.daruda.darudaserver.domain.tool.dto.res.RelatedToolListRes;
+import com.daruda.darudaserver.domain.tool.dto.res.ToolCoreRes;
+import com.daruda.darudaserver.domain.tool.dto.res.ToolDetailGetRes;
 import com.daruda.darudaserver.domain.tool.service.ToolService;
+import com.daruda.darudaserver.global.common.response.ApiResponse;
+import com.daruda.darudaserver.global.error.code.SuccessCode;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,5 +22,40 @@ public class ToolController {
 
     private final ToolService toolService;
 
+    /**
+     * 툴 세부정보 조회
+     */
+    @GetMapping("/{tool-id}")
+    public ResponseEntity<ApiResponse<?>> getToolDetail(@PathVariable(name="tool-id") final Long toolId){
+        ToolDetailGetRes toolDetail = toolService.getToolDetail(toolId);
+        return ResponseEntity.ok(ApiResponse.ofSuccessWithData(toolDetail, SuccessCode.SUCCESS_FETCH));
+    }
+
+    /**
+     * 툴 핵심 기능 조회
+     */
+    @GetMapping("/{tool-id}/core-features")
+    public ResponseEntity<ApiResponse<?>> getToolCoreFeature(@PathVariable(name="tool-id") final Long toolId){
+        ToolCoreRes toolCore = toolService.getToolCore(toolId);
+        return ResponseEntity.ok(ApiResponse.ofSuccessWithData(toolCore, SuccessCode.SUCCESS_FETCH));
+    }
+
+    /**
+     * 툴- 플랜 조회
+     */
+    @GetMapping("/{tool-id}/plans")
+    public ResponseEntity<ApiResponse<?>> getToolPlans(@PathVariable(name="tool-id") final Long toolId){
+        PlanRes plan = toolService.getPlan(toolId);
+        return ResponseEntity.ok(ApiResponse.ofSuccessWithData(plan, SuccessCode.SUCCESS_FETCH));
+    }
+
+    /**
+     * 대안툴 조회
+     */
+    @GetMapping("/{tool-id}/related-tool")
+    public ResponseEntity<ApiResponse<?>> getRelatedTool(@PathVariable(name="tool-id") final Long toolId){
+        RelatedToolListRes relatedTool = toolService.getRelatedTool(toolId);
+        return ResponseEntity.ok(ApiResponse.ofSuccessWithData(relatedTool, SuccessCode.SUCCESS_FETCH));
+    }
 
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
@@ -1,8 +1,17 @@
 package com.daruda.darudaserver.domain.tool.controller;
 
+import com.daruda.darudaserver.domain.tool.service.ToolService;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tools")
 public class ToolController {
+
+    private final ToolService toolService;
+
 
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
@@ -1,9 +1,6 @@
 package com.daruda.darudaserver.domain.tool.controller;
 
-import com.daruda.darudaserver.domain.tool.dto.res.PlanRes;
-import com.daruda.darudaserver.domain.tool.dto.res.RelatedToolListRes;
-import com.daruda.darudaserver.domain.tool.dto.res.ToolCoreRes;
-import com.daruda.darudaserver.domain.tool.dto.res.ToolDetailGetRes;
+import com.daruda.darudaserver.domain.tool.dto.res.*;
 import com.daruda.darudaserver.domain.tool.service.ToolService;
 import com.daruda.darudaserver.global.common.response.ApiResponse;
 import com.daruda.darudaserver.global.error.code.SuccessCode;
@@ -36,7 +33,7 @@ public class ToolController {
      */
     @GetMapping("/{tool-id}/core-features")
     public ResponseEntity<ApiResponse<?>> getToolCoreFeature(@PathVariable(name="tool-id") final Long toolId){
-        ToolCoreRes toolCore = toolService.getToolCore(toolId);
+        ToolCoreListRes toolCore = toolService.getToolCore(toolId);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(toolCore, SuccessCode.SUCCESS_FETCH));
     }
 
@@ -45,7 +42,7 @@ public class ToolController {
      */
     @GetMapping("/{tool-id}/plans")
     public ResponseEntity<ApiResponse<?>> getToolPlans(@PathVariable(name="tool-id") final Long toolId){
-        PlanRes plan = toolService.getPlan(toolId);
+        PlanListRes plan = toolService.getPlan(toolId);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(plan, SuccessCode.SUCCESS_FETCH));
     }
 

--- a/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
@@ -1,0 +1,8 @@
+package com.daruda.darudaserver.domain.tool.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ToolController {
+
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/PlanListRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/PlanListRes.java
@@ -1,0 +1,17 @@
+package com.daruda.darudaserver.domain.tool.dto.res;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record PlanListRes(
+        List<PlanRes> toolCoreResList
+){
+    public static PlanListRes of (List<PlanRes> planRes){
+        return PlanListRes.builder()
+                .toolCoreResList(planRes)
+                .build();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/PlanRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/PlanRes.java
@@ -1,0 +1,24 @@
+package com.daruda.darudaserver.domain.tool.dto.res;
+
+import com.daruda.darudaserver.domain.tool.entity.Plan;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record PlanRes(
+        Long planId,
+        String planName,
+        int monthlyPrice,
+        int annualPrice,
+        String description
+) {
+    public static PlanRes of (final Plan plan){
+        return PlanRes.builder()
+                .planId(plan.getPlanId())
+                .planName(plan.getPlanName())
+                .monthlyPrice(plan.getPriceMonthly())
+                .annualPrice(plan.getPriceAnnual())
+                .description(plan.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/PlatformRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/PlatformRes.java
@@ -1,0 +1,20 @@
+package com.daruda.darudaserver.domain.tool.dto.res;
+
+import com.daruda.darudaserver.domain.tool.entity.ToolPlatForm;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record PlatformRes (
+        Boolean web,
+        Boolean windows,
+        Boolean mac
+) {
+    public static PlatformRes of(ToolPlatForm platForm){
+        return PlatformRes.builder()
+                .web(platForm.getWeb())
+                .windows(platForm.getWindows())
+                .mac(platForm.getMac())
+                .build();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/RelatedToolListRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/RelatedToolListRes.java
@@ -1,0 +1,17 @@
+package com.daruda.darudaserver.domain.tool.dto.res;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record RelatedToolListRes(
+        List<RelatedToolRes> relatedToolResList
+        ) {
+    public static RelatedToolListRes of(List<RelatedToolRes> relatedToolRes){
+        return RelatedToolListRes.builder()
+                .relatedToolResList(relatedToolRes)
+                .build();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/RelatedToolRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/RelatedToolRes.java
@@ -1,0 +1,27 @@
+package com.daruda.darudaserver.domain.tool.dto.res;
+
+import com.daruda.darudaserver.domain.tool.entity.License;
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import lombok.AccessLevel;
+import lombok.Builder;
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record RelatedToolRes (
+        Long toolId,
+        String toolName,
+        String toolLogo,
+        License license,
+        List<String> keywords
+){
+
+    public static RelatedToolRes of(Tool tool,List<String> keywords) {
+        return RelatedToolRes.builder()
+                .toolId(tool.getToolId())
+                .toolName(tool.getToolMainName())
+                .toolLogo(tool.getToolLogo())
+                .license(tool.getLicense())
+                .keywords(keywords)
+                .build();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolCoreListRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolCoreListRes.java
@@ -1,0 +1,16 @@
+package com.daruda.darudaserver.domain.tool.dto.res;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+@Builder(access = AccessLevel.PRIVATE)
+public record ToolCoreListRes (
+        List<ToolCoreRes> toolCoreResList
+){
+    public static ToolCoreListRes of (List<ToolCoreRes> toolCoreResList){
+        return ToolCoreListRes.builder()
+                .toolCoreResList(toolCoreResList)
+                .build();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolCoreRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolCoreRes.java
@@ -1,0 +1,20 @@
+package com.daruda.darudaserver.domain.tool.dto.res;
+
+import com.daruda.darudaserver.domain.tool.entity.ToolCore;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ToolCoreRes(
+        Long coreId,
+        String coreTitle,
+        String coreContent
+) {
+    public static ToolCoreRes of (ToolCore toolCore){
+        return ToolCoreRes.builder()
+                .coreId(toolCore.getCoreId())
+                .coreTitle(toolCore.getCoreTitle())
+                .coreContent(toolCore.getCoreContent())
+                .build();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolDetailGetRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolDetailGetRes.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AccessLevel;
 import lombok.Builder;
 
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -24,7 +25,7 @@ public record ToolDetailGetRes(
         List<String> videos,
         List<String> images,
         @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy.MM.dd",timezone = "Asia/Seoul")
-        LocalDateTime updatedAt
+        Timestamp updatedAt
 ) {
     public static ToolDetailGetRes of( Tool tool, List<PlatformRes> platform, List<String> keywords , List<String> images ,List<String> videos){
 

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolDetailGetRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolDetailGetRes.java
@@ -1,0 +1,51 @@
+package com.daruda.darudaserver.domain.tool.dto.res;
+
+import com.daruda.darudaserver.domain.tool.entity.*;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ToolDetailGetRes(
+        Long toolId,
+        String toolMainName,
+        String toolSubName,
+        String description,
+        License license,
+        List<String> keywords,
+        Category category,
+        String toolLink,
+        Boolean supportKorea,
+        List<PlatformRes> platform,
+        String detailDescription,
+        List<String> videos,
+        List<String> images,
+        @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy.MM.dd",timezone = "Asia/Seoul")
+        LocalDateTime updatedAt
+) {
+    public static ToolDetailGetRes of(Tool tool, List<ToolPlatForm> platform){
+        List<PlatformRes> platformRes = platform.stream()
+                .map(PlatformRes::of)
+                .toList();
+        List<String> keywordRes = tool.getKeywords().stream()
+                .map(ToolKeyword::getKeywordName)
+                .toList();
+
+        return ToolDetailGetRes.builder()
+                .toolId(tool.getToolId())
+                .toolMainName(tool.getToolMainName())
+                .toolSubName(tool.getToolSubName())
+                .description(tool.getDescription())
+                .license(tool.getLicense())
+                .keywords(keywordRes)
+                .category(tool.getCategory())
+                .toolLink(tool.getToolLink())
+                .supportKorea(tool.getSupportKorea())
+                .platform(platformRes)
+                .detailDescription(tool.getDetailDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolDetailGetRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolDetailGetRes.java
@@ -26,13 +26,7 @@ public record ToolDetailGetRes(
         @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy.MM.dd",timezone = "Asia/Seoul")
         LocalDateTime updatedAt
 ) {
-    public static ToolDetailGetRes of(Tool tool, List<ToolPlatForm> platform){
-        List<PlatformRes> platformRes = platform.stream()
-                .map(PlatformRes::of)
-                .toList();
-        List<String> keywordRes = tool.getKeywords().stream()
-                .map(ToolKeyword::getKeywordName)
-                .toList();
+    public static ToolDetailGetRes of( Tool tool, List<PlatformRes> platform, List<String> keywords , List<String> images ,List<String> videos){
 
         return ToolDetailGetRes.builder()
                 .toolId(tool.getToolId())
@@ -40,12 +34,15 @@ public record ToolDetailGetRes(
                 .toolSubName(tool.getToolSubName())
                 .description(tool.getDescription())
                 .license(tool.getLicense())
-                .keywords(keywordRes)
+                .keywords(keywords)
                 .category(tool.getCategory())
                 .toolLink(tool.getToolLink())
                 .supportKorea(tool.getSupportKorea())
-                .platform(platformRes)
+                .platform(platform)
                 .detailDescription(tool.getDetailDescription())
+                .updatedAt(tool.getUpdatedAt())
+                .images(images)
+                .videos(videos)
                 .build();
     }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolDtoGetRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolDtoGetRes.java
@@ -1,7 +1,6 @@
 package com.daruda.darudaserver.domain.tool.dto.res;
 
 import com.daruda.darudaserver.domain.tool.entity.License;
-import com.daruda.darudaserver.domain.tool.entity.ToolKeyword;
 import lombok.AccessLevel;
 import lombok.Builder;
 

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolDtoGetRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolDtoGetRes.java
@@ -1,0 +1,19 @@
+package com.daruda.darudaserver.domain.tool.dto.res;
+
+import com.daruda.darudaserver.domain.tool.entity.License;
+import com.daruda.darudaserver.domain.tool.entity.ToolKeyword;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ToolDtoGetRes(
+        Long toolId,
+        String toolName,
+        String toolLogo,
+        String description,
+        License license,
+        List<String> keywords
+) {
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolListRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/res/ToolListRes.java
@@ -1,0 +1,17 @@
+package com.daruda.darudaserver.domain.tool.dto.res;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ToolListRes (
+        List<ToolDtoGetRes> tools
+){
+    public static ToolListRes of(List<ToolDtoGetRes> tools){
+        return ToolListRes.builder()
+                .tools(tools)
+                .build();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Category.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Category.java
@@ -1,0 +1,28 @@
+package com.daruda.darudaserver.domain.tool.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Category {
+    LIFESTYLE("라이프스타일"),
+    DOCUMENT_EDITING("문서 편집"),
+    AI("인공지능"),
+    COLLABORATION("협업"),
+    CODING("코딩"),
+    DESIGN_MODELING("디자인/모델링"),
+    DATA("데이터"),
+    PRESENTATION("프레젠테이션"),
+    GRAPHIC_DESIGN("그래픽 디자인"),
+    VIDEO_MUSIC("영상/음악"),
+    CAREER_DEVELOPMENT("커리어 개발");
+
+    private final String koreanName;
+
+    Category(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/License.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/License.java
@@ -1,0 +1,22 @@
+package com.daruda.darudaserver.domain.tool.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum License {
+    FREE("무료"),
+    PARTIALLY_FREE("부분 무료"),
+    PAID("유료");
+
+    private final String koreanName;
+
+    // 생성자
+    License(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    // Getter 메서드
+    public String getKoreanName() {
+        return koreanName;
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Plan.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Plan.java
@@ -25,8 +25,8 @@ public class Plan {
     @Column(name = "plan_annual",nullable = false)
     private int priceAnnual;
 
-    @Column(name = "feature",nullable = false)
-    private String feature;
+    @Column(name = "description",nullable = false)
+    private String description;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="tool_id",nullable = false)

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Plan.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Plan.java
@@ -1,0 +1,35 @@
+package com.daruda.darudaserver.domain.tool.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.w3c.dom.Text;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Getter
+@Table(name="plan")
+public class Plan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long planId;
+
+    @Column(name = "plan_name",nullable = false)
+    private String planName;
+
+    @Column(name = "plan_monthly",nullable = false)
+    private int priceMonthly;
+
+    @Column(name = "plan_annual",nullable = false)
+    private int priceAnnual;
+
+    @Column(name = "feature",nullable = false)
+    private String feature;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="tool_id",nullable = false)
+    private Tool tool;
+
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Plan.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Plan.java
@@ -20,10 +20,10 @@ public class Plan {
     @Column(name = "plan_name",nullable = false)
     private String planName;
 
-    @Column(name = "plan_monthly",nullable = false)
+    @Column(name = "price_monthly",nullable = false)
     private int priceMonthly;
 
-    @Column(name = "plan_annual",nullable = false)
+    @Column(name = "price_annual",nullable = false)
     private int priceAnnual;
 
     @Column(name = "description",nullable = false)

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Plan.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Plan.java
@@ -4,8 +4,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.w3c.dom.Text;
-
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Getter

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/RelatedTool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/RelatedTool.java
@@ -1,0 +1,25 @@
+package com.daruda.darudaserver.domain.tool.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Getter
+@Table(name="related_tool")
+public class RelatedTool {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long relatedToolId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="tool_id",nullable = false)
+    private Tool tool;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "alternative_tool", nullable = false)
+    private Tool alternativeTool;
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/RelatedTool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/RelatedTool.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Getter

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
@@ -4,10 +4,7 @@ import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -15,6 +12,7 @@ import java.util.List;
 @Table(name="tool")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 @Builder
 public class Tool extends BaseTimeEntity {
 
@@ -56,5 +54,8 @@ public class Tool extends BaseTimeEntity {
 
     @Column(name="toolLogo",nullable = false)
     private String toolLogo;
+
+    @OneToMany(mappedBy = "toolId", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ToolKeyword> keywords;
 
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.sql.Timestamp;
 import java.util.List;
 
 @Entity
@@ -14,7 +15,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @Builder
-public class Tool extends BaseTimeEntity {
+public class Tool {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,5 +58,27 @@ public class Tool extends BaseTimeEntity {
 
     @Column(columnDefinition="integer default 0",nullable = false)
     private int viewCount;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Timestamp createdAt;
+
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
+
+    // createdAt 값을 설정하는 메서드
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = new Timestamp(System.currentTimeMillis());
+    }
+
+    // updatedAt 값을 수동으로 설정하는 메서드
+    public void setUpdatedAt(Timestamp updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    // viewCount를 업데이트하는 메서드 (updatedAt에 영향 없음)
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
 
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
@@ -52,7 +52,10 @@ public class Tool extends BaseTimeEntity {
     @Column(name="color",nullable = false)
     private String color;
 
-    @Column(name="toolLogo",nullable = false)
+    @Column(name="tool_logo",nullable = false)
     private String toolLogo;
+
+    @Column(columnDefinition="integer default 0",nullable = false)
+    private int viewCount;
 
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
@@ -9,59 +9,52 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Entity
 @Table(name="tool")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class tool extends BaseTimeEntity {
+public class Tool extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long toolId;
 
-    @NotNull
-    @Column(name = "tool_main_name")
+    @Column(name = "tool_main_name", nullable = false)
     private String toolMainName;
 
-    @NotNull
-    @Column(name = "tool_sub_name")
+    @Column(name = "tool_sub_name", nullable = false)
     private String toolSubName;
 
-    @NotNull
-    @Column(name = "category")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
     private Category category;
 
-    @NotNull
-    @Column(name = "tool_link")
+    @Column(name = "tool_link", nullable = false)
     private String toolLink;
 
-    @NotNull
-    @Column(name = "description")
+    @Column(name = "description", nullable = false)
     private String description;
 
-    @NotNull
-    @Column(name = "license")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "license" , nullable = false)
     private License license;
 
-    @NotNull
-    @Column(name = "support_korea")
+    @Column(name = "support_korea", nullable = false)
     private Boolean supportKorea;
 
-    @NotNull
-    @Column(name="detail_description")
+    @Column(name="detail_description",nullable = false)
     private String detailDescription;
 
-    @Nullable
     @Column(name="plan_link")
     private String planLink;
 
-    @NotNull
-    @Column(name="color")
+    @Column(name="color",nullable = false)
     private String color;
 
-    @NotNull
-    @Column(name="toolLogo")
+    @Column(name="toolLogo",nullable = false)
     private String toolLogo;
 
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
@@ -55,7 +55,4 @@ public class Tool extends BaseTimeEntity {
     @Column(name="toolLogo",nullable = false)
     private String toolLogo;
 
-    @OneToMany(mappedBy = "toolId", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ToolKeyword> keywords;
-
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolCore.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolCore.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Getter

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolCore.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolCore.java
@@ -1,0 +1,27 @@
+package com.daruda.darudaserver.domain.tool.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Getter
+@Table(name="core_feature")
+public class ToolCore {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long coreId;
+
+    @Column(name="core_title",nullable = false)
+    private String coreTitle;
+
+    @Column(name="core_content",nullable = false)
+    private String coreContent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="tool_id",nullable = false)
+    private Tool tool;
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolImage.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolImage.java
@@ -6,19 +6,20 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
-@Table(name="tool_keyword")
-public class ToolKeyword {
-
+@Table(name="tool_image")
+public class ToolImage {
     @Id
-    @Column(name = "keyword_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long keywordId;
+    @Column(name="tool_image_id")
+    private Long imageId;
 
-    @Column(name="keyword_name",nullable = false)
-    private String keywordName;
+    @Column(name="image_url",nullable = false)
+    private String imageUrl;
+
+    @Column(name="image_order", nullable = false)
+    private int imageOrder;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="tool_id",nullable = false)
-    private Tool toolId ;
-
+    private Tool toolId;
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolImage.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolImage.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Getter

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolImage.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolImage.java
@@ -3,9 +3,11 @@ package com.daruda.darudaserver.domain.tool.entity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
+@Getter
 @Table(name="tool_image")
 public class ToolImage {
     @Id
@@ -21,5 +23,5 @@ public class ToolImage {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="tool_id",nullable = false)
-    private Tool toolId;
+    private Tool tool;
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolKeyword.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolKeyword.java
@@ -3,9 +3,11 @@ package com.daruda.darudaserver.domain.tool.entity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
+@Getter
 @Table(name="tool_keyword")
 public class ToolKeyword {
 
@@ -16,9 +18,5 @@ public class ToolKeyword {
 
     @Column(name="keyword_name",nullable = false)
     private String keywordName;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="tool_id",nullable = false)
-    private Tool toolId ;
 
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolKeyword.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolKeyword.java
@@ -19,4 +19,8 @@ public class ToolKeyword {
     @Column(name="keyword_name",nullable = false)
     private String keywordName;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="tool_id",nullable = false)
+    private Tool tool;
+
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolKeyword.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolKeyword.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Getter

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolKeyword.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolKeyword.java
@@ -1,0 +1,24 @@
+package com.daruda.darudaserver.domain.tool.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name="tool_keyword")
+public class ToolKeyword {
+
+    @Id
+    @Column(name = "keyword_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long keywordId;
+
+    @Column(name="keyword_name")
+    private String keywordName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="tool_id",nullable = false)
+    private Tool toolId ;
+
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
@@ -1,0 +1,29 @@
+package com.daruda.darudaserver.domain.tool.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name="tool_platform")
+public class ToolPlatForm {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "platform_id")
+    private Long platformId;
+
+    @Column(name="web")
+    private Boolean web;
+
+    @Column(name="windows")
+    private Boolean windows;
+
+    @Column(name="mac")
+    private Boolean mac;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="tool_id",nullable = false)
+    private Tool toolId;
+
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
@@ -3,9 +3,11 @@ package com.daruda.darudaserver.domain.tool.entity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
+@Getter
 @Table(name="tool_platform")
 public class ToolPlatForm {
     @Id

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Getter

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
@@ -26,6 +26,6 @@ public class ToolPlatForm {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="tool_id",nullable = false)
-    private Tool toolId;
+    private Tool tool;
 
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
@@ -13,13 +13,13 @@ public class ToolPlatForm {
     @Column(name = "platform_id")
     private Long platformId;
 
-    @Column(name="web")
+    @Column(name="web",nullable = false)
     private Boolean web;
 
-    @Column(name="windows")
+    @Column(name="windows",nullable = false)
     private Boolean windows;
 
-    @Column(name="mac")
+    @Column(name="mac",nullable = false)
     private Boolean mac;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolVideo.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolVideo.java
@@ -3,9 +3,11 @@ package com.daruda.darudaserver.domain.tool.entity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
+@Getter
 @Table(name="tool_video")
 public class ToolVideo {
     @Id
@@ -18,6 +20,6 @@ public class ToolVideo {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="tool_id",nullable = false)
-    private Tool toolId;
+    private Tool tool;
 
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolVideo.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolVideo.java
@@ -1,0 +1,23 @@
+package com.daruda.darudaserver.domain.tool.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name="tool_video")
+public class ToolVideo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="tool_video_id")
+    private Long videoId;
+
+    @Column(name="tool_video_url")
+    private String videoUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="tool_id",nullable = false)
+    private Tool toolId;
+
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolVideo.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolVideo.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Getter

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolVideo.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolVideo.java
@@ -13,7 +13,7 @@ public class ToolVideo {
     @Column(name="tool_video_id")
     private Long videoId;
 
-    @Column(name="tool_video_url")
+    @Column(name="tool_video_url",nullable = false)
     private String videoUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/tool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/tool.java
@@ -1,0 +1,67 @@
+package com.daruda.darudaserver.domain.tool.entity;
+
+import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="tool")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class tool extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long toolId;
+
+    @NotNull
+    @Column(name = "tool_main_name")
+    private String toolMainName;
+
+    @NotNull
+    @Column(name = "tool_sub_name")
+    private String toolSubName;
+
+    @NotNull
+    @Column(name = "category")
+    private Category category;
+
+    @NotNull
+    @Column(name = "tool_link")
+    private String toolLink;
+
+    @NotNull
+    @Column(name = "description")
+    private String description;
+
+    @NotNull
+    @Column(name = "license")
+    private License license;
+
+    @NotNull
+    @Column(name = "support_korea")
+    private Boolean supportKorea;
+
+    @NotNull
+    @Column(name="detail_description")
+    private String detailDescription;
+
+    @Nullable
+    @Column(name="plan_link")
+    private String planLink;
+
+    @NotNull
+    @Column(name="color")
+    private String color;
+
+    @NotNull
+    @Column(name="toolLogo")
+    private String toolLogo;
+
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/PlanRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/PlanRepository.java
@@ -5,10 +5,11 @@ import com.daruda.darudaserver.domain.tool.entity.Tool;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PlanRepository extends JpaRepository<Plan,Long> {
 
-    Optional<Plan> findByTool(Tool tool);
+    List<Plan> findAllByTool(Tool tool);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/PlanRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/PlanRepository.java
@@ -1,0 +1,14 @@
+package com.daruda.darudaserver.domain.tool.repository;
+
+import com.daruda.darudaserver.domain.tool.entity.Plan;
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PlanRepository extends JpaRepository<Plan,Long> {
+
+    Optional<Plan> findByTool(Tool tool);
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/RelatedToolRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/RelatedToolRepository.java
@@ -1,0 +1,14 @@
+package com.daruda.darudaserver.domain.tool.repository;
+
+
+import com.daruda.darudaserver.domain.tool.entity.RelatedTool;
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RelatedToolRepository extends JpaRepository<RelatedTool,Long> {
+    List<RelatedTool> findAllByTool(Tool tool);
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolCoreRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolCoreRepository.java
@@ -5,9 +5,10 @@ import com.daruda.darudaserver.domain.tool.entity.ToolCore;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ToolCoreRepository extends JpaRepository<ToolCore,Long> {
-    Optional<ToolCore> findByTool(Tool tool);
+    List<ToolCore> findAllByTool(Tool tool);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolCoreRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolCoreRepository.java
@@ -1,0 +1,13 @@
+package com.daruda.darudaserver.domain.tool.repository;
+
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import com.daruda.darudaserver.domain.tool.entity.ToolCore;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ToolCoreRepository extends JpaRepository<ToolCore,Long> {
+    Optional<ToolCore> findByTool(Tool tool);
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolImageRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolImageRepository.java
@@ -1,0 +1,13 @@
+package com.daruda.darudaserver.domain.tool.repository;
+
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import com.daruda.darudaserver.domain.tool.entity.ToolImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ToolImageRepository extends JpaRepository<ToolImage,Long> {
+    List<ToolImage> findAllByTool(final Tool toolId);
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolKeywordRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolKeywordRepository.java
@@ -1,0 +1,13 @@
+package com.daruda.darudaserver.domain.tool.repository;
+
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import com.daruda.darudaserver.domain.tool.entity.ToolKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ToolKeywordRepository extends JpaRepository<ToolKeyword,Long> {
+    List<ToolKeyword> findAllByTool(final Tool toolById);
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolPlatFormRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolPlatFormRepository.java
@@ -1,0 +1,13 @@
+package com.daruda.darudaserver.domain.tool.repository;
+
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import com.daruda.darudaserver.domain.tool.entity.ToolPlatForm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ToolPlatFormRepository extends JpaRepository<ToolPlatForm,Long> {
+    List<ToolPlatForm> findAllByTool(final Tool toolId);
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolRepository.java
@@ -2,8 +2,14 @@ package com.daruda.darudaserver.domain.tool.repository;
 
 import com.daruda.darudaserver.domain.tool.entity.Tool;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ToolRepository extends JpaRepository<Tool,Long> {
+
+    @Modifying
+    @Query("update Tool t set t.viewCount = t.viewCount + 1 where t.toolId = :id")
+    int updateView(Long id);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolRepository.java
@@ -1,6 +1,7 @@
 package com.daruda.darudaserver.domain.tool.repository;
 
 import com.daruda.darudaserver.domain.tool.entity.Tool;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ToolRepository extends JpaRepository<Tool,Long> {
 
+    @Transactional
     @Modifying
     @Query("update Tool t set t.viewCount = t.viewCount + 1 where t.toolId = :id")
     int updateView(Long id);

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolRepository.java
@@ -1,0 +1,9 @@
+package com.daruda.darudaserver.domain.tool.repository;
+
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ToolRepository extends JpaRepository<Tool,Long> {
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolVideoRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolVideoRepository.java
@@ -1,0 +1,13 @@
+package com.daruda.darudaserver.domain.tool.repository;
+
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import com.daruda.darudaserver.domain.tool.entity.ToolVideo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ToolVideoRepository extends JpaRepository<ToolVideo,Long> {
+    List<ToolVideo> findAllByTool(final Tool toolId);
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -13,9 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Transactional(readOnly = true)
 @Service
 @Slf4j
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ToolService {
 
@@ -28,7 +28,7 @@ public class ToolService {
     private final ToolCoreRepository toolCoreRepository;
     private final RelatedToolRepository relatedToolRepository;
 
-
+    @Transactional
     public ToolDetailGetRes getToolDetail(final Long toolId) {
         log.info("툴 세부 정보를 조회합니다. toolId={}", toolId);
 

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -1,13 +1,69 @@
 package com.daruda.darudaserver.domain.tool.service;
 
 
+import com.daruda.darudaserver.domain.tool.dto.res.PlatformRes;
 import com.daruda.darudaserver.domain.tool.dto.res.ToolDetailGetRes;
+import com.daruda.darudaserver.domain.tool.entity.*;
+import com.daruda.darudaserver.domain.tool.repository.*;
+import com.daruda.darudaserver.global.error.code.ErrorCode;
+import com.daruda.darudaserver.global.error.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+@Transactional
 @Service
+@RequiredArgsConstructor
 public class ToolService {
 
-    private ToolDetailGetRes getToolDetail(){
+    private final ToolRepository toolRepository;
+    private final ToolImageRepository toolImageRepository;
+    private final ToolPlatFormRepository toolPlatFormRepository;
+    private final ToolVideoRepository toolVideoRepository;
+    private final ToolKeywordRepository toolKeywordRepository;
 
+
+    public ToolDetailGetRes getToolDetail(final Long toolId){
+        Tool tool = getToolById(toolId);
+        List<String> images = getImageById(tool);
+        List<PlatformRes> platformRes = convertToPlatformRes(tool);
+        List<String> keywordRes = convertToKeywordRes(tool);
+        List<String> videos = getVideoById(tool);
+        return ToolDetailGetRes.of(tool,platformRes,keywordRes, images,videos);
+    }
+
+    private Tool getToolById(final Long toolId){
+            return toolRepository.findById(toolId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DATA_NOT_FOUND));
+    }
+
+    private List<String> getImageById(final Tool tool){
+        List<ToolImage> toolImages = toolImageRepository.findAllByTool(tool);
+        return toolImages.stream()
+                .map(ToolImage::getImageUrl)
+                .toList();
+    }
+
+    private List<String> getVideoById(final Tool tool){
+        List<ToolVideo> toolVideos = toolVideoRepository.findAllByTool(tool);
+        return toolVideos.stream()
+                .map(ToolVideo::getVideoUrl)
+                .toList();
+    }
+
+    private List<PlatformRes> convertToPlatformRes(Tool tool) {
+        List<ToolPlatForm> toolPlatForms = toolPlatFormRepository.findAllByTool(tool);
+         return toolPlatForms.stream()
+                .map(PlatformRes::of)
+                .toList();
+    }
+
+    private List<String> convertToKeywordRes(Tool tool) {
+        List<ToolKeyword> toolKeywords = toolKeywordRepository.findAllByTool(tool);
+        return toolKeywords.stream()
+                .map(ToolKeyword::getKeywordName)
+                .toList();
     }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -1,8 +1,13 @@
 package com.daruda.darudaserver.domain.tool.service;
 
+
+import com.daruda.darudaserver.domain.tool.dto.res.ToolDetailGetRes;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ToolService {
 
+    private ToolDetailGetRes getToolDetail(){
+
+    }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -1,0 +1,8 @@
+package com.daruda.darudaserver.domain.tool.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ToolService {
+
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -33,6 +33,7 @@ public class ToolService {
         List<PlatformRes> platformRes = convertToPlatformRes(tool);
         List<String> keywordRes = convertToKeywordRes(tool);
         List<String> videos = getVideoById(tool);
+        updateView(toolId);
         return ToolDetailGetRes.of(tool,platformRes,keywordRes, images,videos);
     }
 
@@ -79,8 +80,6 @@ public class ToolService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.DATA_NOT_FOUND));
     }
 
-
-
     private List<String> getImageById(final Tool tool){
         List<ToolImage> toolImages = toolImageRepository.findAllByTool(tool);
         return toolImages.stream()
@@ -107,5 +106,9 @@ public class ToolService {
         return toolKeywords.stream()
                 .map(ToolKeyword::getKeywordName)
                 .toList();
+    }
+
+    public int updateView(Long toolId){
+        return toolRepository.updateView(toolId);
     }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -93,6 +93,7 @@ public class ToolService {
     private List<PlanRes> getPlanByTool(final Tool tool) {
         log.debug("툴에 연결된 플랜 정보를 조회합니다. toolId={}", tool.getToolId());
         List<Plan> planList = planRepository.findAllByTool(tool);
+        validateList(planList);
         return planList.stream()
                 .map(PlanRes::of)
                 .toList();

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -7,6 +7,7 @@ import com.daruda.darudaserver.domain.tool.repository.*;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +15,7 @@ import java.util.List;
 
 @Transactional
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ToolService {
 
@@ -27,30 +29,46 @@ public class ToolService {
     private final RelatedToolRepository relatedToolRepository;
 
 
-    public ToolDetailGetRes getToolDetail(final Long toolId){
+    public ToolDetailGetRes getToolDetail(final Long toolId) {
+        log.info("툴 세부 정보를 조회합니다. toolId={}", toolId);
+
         Tool tool = getToolById(toolId);
         List<String> images = getImageById(tool);
         List<PlatformRes> platformRes = convertToPlatformRes(tool);
         List<String> keywordRes = convertToKeywordRes(tool);
         List<String> videos = getVideoById(tool);
         updateView(toolId);
-        return ToolDetailGetRes.of(tool,platformRes,keywordRes, images,videos);
+
+        log.info("툴 세부 정보를 성공적으로 조회했습니다. toolId={}", toolId);
+        return ToolDetailGetRes.of(tool, platformRes, keywordRes, images, videos);
     }
 
-    public PlanRes getPlan(final Long toolId){
+    public PlanRes getPlan(final Long toolId) {
+        log.info("플랜 정보를 조회합니다. toolId={}", toolId);
+
         Tool tool = getToolById(toolId);
         Plan plan = getPlanByTool(tool);
+
+        log.info("플랜 정보를 성공적으로 조회했습니다. toolId={}", toolId);
         return PlanRes.of(plan);
     }
-    public ToolCoreRes getToolCore(final Long toolId){
+
+    public ToolCoreRes getToolCore(final Long toolId) {
+        log.info("툴 핵심 정보를 조회합니다. toolId={}", toolId);
+
         Tool tool = getToolById(toolId);
         ToolCore toolCore = getToolCoreByTool(tool);
+
+        log.info("툴 핵심 정보를 성공적으로 조회했습니다. toolId={}", toolId);
         return ToolCoreRes.of(toolCore);
     }
 
-    public RelatedToolListRes getRelatedTool(final Long toolId){
+    public RelatedToolListRes getRelatedTool(final Long toolId) {
+        log.info("관련 툴 정보를 조회합니다. toolId={}", toolId);
+
         Tool tool = getToolById(toolId);
         List<RelatedTool> relatedTools = relatedTool(tool);
+
         List<RelatedToolRes> relatedToolResList = relatedTools.stream()
                 .map(relatedTool -> {
                     Tool related = relatedTool.getAlternativeTool();
@@ -58,37 +76,54 @@ public class ToolService {
                     return RelatedToolRes.of(related, keywords);
                 })
                 .toList();
+
+        log.info("관련 툴 정보를 성공적으로 조회했습니다. toolId={}", toolId);
         return RelatedToolListRes.of(relatedToolResList);
     }
 
-    private List<RelatedTool> relatedTool(final Tool tool){
+    private List<RelatedTool> relatedTool(final Tool tool) {
+        log.debug("툴의 관련 툴 데이터를 조회합니다. toolId={}", tool.getToolId());
         return relatedToolRepository.findAllByTool(tool);
     }
 
-    private Tool getToolById(final Long toolId){
-            return toolRepository.findById(toolId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.DATA_NOT_FOUND));
+    private Tool getToolById(final Long toolId) {
+        log.debug("툴을 조회합니다. toolId={}", toolId);
+        return toolRepository.findById(toolId)
+                .orElseThrow(() -> {
+                    log.error("툴을 찾을 수 없습니다. toolId={}", toolId);
+                    return new NotFoundException(ErrorCode.DATA_NOT_FOUND);
+                });
     }
 
-    private Plan getPlanByTool(final Tool tool){
+    private Plan getPlanByTool(final Tool tool) {
+        log.debug("툴에 연결된 플랜 정보를 조회합니다. toolId={}", tool.getToolId());
         return planRepository.findByTool(tool)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.DATA_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.error("플랜 정보를 찾을 수 없습니다. toolId={}", tool.getToolId());
+                    return new NotFoundException(ErrorCode.DATA_NOT_FOUND);
+                });
     }
 
-    private ToolCore getToolCoreByTool(final Tool tool){
+    private ToolCore getToolCoreByTool(final Tool tool) {
+        log.debug("툴에 연결된 핵심 정보를 조회합니다. toolId={}", tool.getToolId());
         return toolCoreRepository.findByTool(tool)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.DATA_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.error("핵심 정보를 찾을 수 없습니다. toolId={}", tool.getToolId());
+                    return new NotFoundException(ErrorCode.DATA_NOT_FOUND);
+                });
     }
 
-    private List<String> getImageById(final Tool tool){
+    private List<String> getImageById(final Tool tool) {
         List<ToolImage> toolImages = toolImageRepository.findAllByTool(tool);
+        log.debug("툴에 연결된 플랫폼 정보를 조회했습니다");
         return toolImages.stream()
                 .map(ToolImage::getImageUrl)
                 .toList();
     }
 
-    private List<String> getVideoById(final Tool tool){
+    private List<String> getVideoById(final Tool tool) {
         List<ToolVideo> toolVideos = toolVideoRepository.findAllByTool(tool);
+        log.debug("툴에 연결된 비디오 목록을 조회했습니다");
         return toolVideos.stream()
                 .map(ToolVideo::getVideoUrl)
                 .toList();
@@ -96,19 +131,22 @@ public class ToolService {
 
     private List<PlatformRes> convertToPlatformRes(Tool tool) {
         List<ToolPlatForm> toolPlatForms = toolPlatFormRepository.findAllByTool(tool);
-         return toolPlatForms.stream()
+        log.debug("툴에 연결된 플랫폼 정보를 조회했습니다");
+        return toolPlatForms.stream()
                 .map(PlatformRes::of)
                 .toList();
     }
 
     private List<String> convertToKeywordRes(Tool tool) {
+        log.debug("툴에 연결된 키워드 정보를 조회했습니다");
         List<ToolKeyword> toolKeywords = toolKeywordRepository.findAllByTool(tool);
         return toolKeywords.stream()
                 .map(ToolKeyword::getKeywordName)
                 .toList();
     }
 
-    public int updateView(Long toolId){
+    public int updateView(Long toolId) {
+        log.debug("툴 조회수를 증가시킵니다. toolId={}", toolId);
         return toolRepository.updateView(toolId);
     }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -13,9 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@Transactional
 @Service
 @Slf4j
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ToolService {
 
@@ -45,30 +45,24 @@ public class ToolService {
 
     public PlanRes getPlan(final Long toolId) {
         log.info("플랜 정보를 조회합니다. toolId={}", toolId);
-
         Tool tool = getToolById(toolId);
         Plan plan = getPlanByTool(tool);
-
         log.info("플랜 정보를 성공적으로 조회했습니다. toolId={}", toolId);
         return PlanRes.of(plan);
     }
 
     public ToolCoreRes getToolCore(final Long toolId) {
-        log.info("툴 핵심 정보를 조회합니다. toolId={}", toolId);
-
+        log.debug("툴 핵심 정보를 조회합니다. toolId={}", toolId);
         Tool tool = getToolById(toolId);
         ToolCore toolCore = getToolCoreByTool(tool);
-
         log.info("툴 핵심 정보를 성공적으로 조회했습니다. toolId={}", toolId);
         return ToolCoreRes.of(toolCore);
     }
 
     public RelatedToolListRes getRelatedTool(final Long toolId) {
         log.info("관련 툴 정보를 조회합니다. toolId={}", toolId);
-
         Tool tool = getToolById(toolId);
         List<RelatedTool> relatedTools = relatedTool(tool);
-
         List<RelatedToolRes> relatedToolResList = relatedTools.stream()
                 .map(relatedTool -> {
                     Tool related = relatedTool.getAlternativeTool();
@@ -82,7 +76,7 @@ public class ToolService {
     }
 
     private List<RelatedTool> relatedTool(final Tool tool) {
-        log.debug("툴의 관련 툴 데이터를 조회합니다. toolId={}", tool.getToolId());
+        log.info("툴의 관련 툴 데이터를 조회합니다. toolId={}", tool.getToolId());
         return relatedToolRepository.findAllByTool(tool);
     }
 

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/CustomAccessDeniedHandler.java
@@ -5,9 +5,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
@@ -2,31 +2,63 @@ package com.daruda.darudaserver.global.auth.security;
 
 import com.daruda.darudaserver.global.auth.jwt.provider.JwtTokenProvider;
 
+import com.daruda.darudaserver.global.auth.jwt.provider.JwtValidationType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException{
-        final String accessToken = getAccessToken(request);
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.debug("JwtAuthenticationFilter 시작: 요청 URL - {}", request.getRequestURI());
+        try {
+            final String accessToken = getAccessToken(request);
+            if (accessToken != null && jwtTokenProvider.validateToken(accessToken) == JwtValidationType.VALID_JWT) {
+                Long userId = jwtTokenProvider.getUserIdFromJwt(accessToken);
+                doAuthentication(request, userId);
+                log.info("JWT 인증 성공 - 사용자 ID: {}", userId);
+            }
+        } catch (Exception e) {
+            log.error("JWT 인증 실패: {}", e.getMessage());
+        }
+        log.debug("JwtAuthenticationFilter 종료: 요청 URL - {}", request.getRequestURI());
+        filterChain.doFilter(request, response);
     }
+
+
+    private static final List<String> EXCLUDE_URL = Arrays.asList("/api/users/**", "/api/v1/tools/**");
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+
+        String path = request.getServletPath();
+        boolean isExcluded = EXCLUDE_URL.stream().anyMatch(exclude -> new AntPathMatcher().match(exclude, path));
+        log.debug("Checking shouldNotFilter for path: {}, excluded: {}", path, isExcluded);
+        return isExcluded;
+    }
+
+
 
     private String getAccessToken(HttpServletRequest request){
         String accessToken = request.getHeader("Authorization");

--- a/src/main/java/com/daruda/darudaserver/global/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/daruda/darudaserver/global/common/entity/BaseTimeEntity.java
@@ -21,11 +21,11 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
-    @Column(name = "created_at",updatable = false)
+    @Column(name = "created_at",updatable = false,nullable = false)
     @CreationTimestamp
     private Timestamp createdAt;
 
-    @Column(name="updated_at")
+    @Column(name="updated_at",nullable = false)
     @UpdateTimestamp
     private Timestamp updatedAt;
 }

--- a/src/main/java/com/daruda/darudaserver/global/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/daruda/darudaserver/global/common/entity/BaseTimeEntity.java
@@ -13,6 +13,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 @Getter
@@ -21,10 +22,10 @@ import java.time.LocalDateTime;
 public abstract class BaseTimeEntity {
 
     @Column(name = "created_at",updatable = false)
-    @CreatedDate
-    private LocalDateTime createdAt;
+    @CreationTimestamp
+    private Timestamp createdAt;
 
     @Column(name="updated_at")
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
+    @UpdateTimestamp
+    private Timestamp updatedAt;
 }

--- a/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
@@ -4,8 +4,10 @@ import com.daruda.darudaserver.global.auth.jwt.provider.JwtTokenProvider;
 import com.daruda.darudaserver.global.auth.security.CustomAccessDeniedHandler;
 import com.daruda.darudaserver.global.auth.security.JwtAuthenticationEntryPoint;
 import com.daruda.darudaserver.global.auth.security.JwtAuthenticationFilter;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -16,12 +18,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @RequiredArgsConstructor
 @EnableWebSecurity
-
+@Configuration
 public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtTokenProvider jwtTokenProvider;
 
-    private static final String[] whiteList = {"/api/users/**"};
+    private static final String[] whiteList = {"/api/users/**","/api/v1/tools/**"};
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -47,5 +49,4 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring().requestMatchers(whiteList);
     }
-
 }

--- a/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
+++ b/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
@@ -28,17 +28,15 @@ public enum ErrorCode {
     AUTHENTICATION_CODE_EXPIRED(HttpStatus.UNAUTHORIZED,"E401001", "인가코드가 만료되었습니다"),
     REFRESH_TOKEN_EXPIRED_ERROR(HttpStatus.UNAUTHORIZED,"E401002","리프레쉬 토큰이 만료되었습니다"),
 
+
     /* 404 NOT FOUND */
+
     DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "E404001","데이터가 존재하지 않습니다"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "E404002", "유저가 존재하지 않습니다"),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND,"E404003", "리프레쉬 토큰이 존재하지 않습니다"),
 
-
     /* 500 INTERNAL SERVER ERROR */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500001","서버 내부에서 오류가 발생했습니다"),
-    FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E500002", "이미지 업로드에 실패했습니다"),
-    FILE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "E500003", "이미지를 찾을 수 없습니다"),
-    FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E500004", "이미지 삭제에 실패했습니다");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500001","서버 내부에서 오류가 발생했습니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
+++ b/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
@@ -36,7 +36,10 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND,"E404003", "리프레쉬 토큰이 존재하지 않습니다"),
 
     /* 500 INTERNAL SERVER ERROR */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500001","서버 내부에서 오류가 발생했습니다");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500001","서버 내부에서 오류가 발생했습니다"),
+    FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E500002", "이미지 업로드에 실패했습니다"),
+    FILE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "E500003", "이미지를 찾을 수 없습니다"),
+    FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E500004", "이미지 삭제에 실패했습니다");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #18 

## 📝 Summary
- 툴 상세조회 API 구현  ( 툴 관련 기본 정적 정보)
- 대안 툴 조회 API 구현
- 툴 플랜 조회 API 구현
- 툴 핵심 기능 조회 API 구현

- TimeStamp 로 변경
- Tool 은 updatedAt, createdAt 을 직접 넣어야하기 때문에 , 자동생성을 막기 위해 BaseTimeEntity extends 안함!

## 🙏 Question & PR point

### 생성자 어노테이션 사용에 관하여
일단 한 번 정리해보고 갈까요! 
- @NoArgsConstructor : 기본 생성자만드는데 사용
- @AllArgsConstructor : 모든 필드의 생성자 만드는데 사용
- @RequiredArgsConStructor : final 과 같은 필수 생성자를 만드는데 사용 
####  record 에서 Builder(accss = AccessLevel.PRIVATE) 으로 설정한 이유
- 빌더 패턴을 통해서만 객체를 생성하도 록 하기 위해서
- 필드를 설정한 후 생성할 수 있으므로 안전하게 생성할 수 있다
- 무분별하게 객체를 생성하는 것을 막으면서, Builder 패턴을 통해 안전하고 의도한대로 필요한 필드에 대한 값을 객체에 넣기 위해 사용하였습니다
#### @NoargsConstructor(AccessLevel.PROTECTED)
- 무분별한 객체 생성을 막을 수 있다. 모든 필드 값을 가지고 있어야 하는 경우에 기본 생성자를 제한하여 누락되는 일을 막도록 하였습니다. 
- 따라서, @NoargsConstructor 과 @Builder 를 같이 쓸 경우 에러가 나기 때문에 모든 멤버 변수를 받는 @AllArgsContructor 를 추가하되, accessLevel 을 private 으로 하여 다른 클래스에서 객체를 생성하는 것을 제한하였습니다.
[참고](https://cobbybb.tistory.com/14)
####  Return 값에 대한 고민
- List 리턴을 할 때 빈 배열로 줘야할지, Exception 으로 주어야할지 고민했습니다 .  단일 정보 조회라면 Id 를 못찾으면 Exception 을 날려주는게 당연해보였지만, List 의 경우에는 경우에 따라 리스트가 빈 배열일 수도 (무료 플랜은 플랜이 없음) 있어서 같은 NotFoundException 으로 주는게 맞는기 고민이 되었습니다. 고민 결과,  Exception 으로 주었습니다. 임시 더미 데이터 이기 때문에 현재 빈 배열의 응답이 생기는 거지, 완성된 더미 데이터의 경우 빈 배열이 생기지 않을 것이라 생각했습니다. 
- 세부적인 Exception 처리. 지금은 Exception 을 NotFoundException 으로 처리하였는데, 클라분들과 이야기해본 후 Exception 을 더 보충할지 생각중입니다! 
#### 조회수 ( 인기순 정렬 위함)
- 상세 정보 조회시 조회수 count +1
- DB에 조회수 필드 추가 ( 디폴트 값 = 0)


## 📬 Postman
- 툴 상세 정보 조회 
<img width="1043" alt="Screenshot 2025-01-12 at 1 41 00 AM" src="https://github.com/user-attachments/assets/098666a5-d595-4f14-8b37-d6008e9e2900" />
- 대안 툴 조회
<img width="749" alt="Screenshot 2025-01-12 at 1 39 32 AM" src="https://github.com/user-attachments/assets/219cb9ec-bd94-48f7-ac78-6c3da12644f6" />
- 툴 플랜 조회
<img width="1044" alt="Screenshot 2025-01-12 at 1 40 04 AM" src="https://github.com/user-attachments/assets/914552cc-1764-4e93-9dcb-8547e05631dd" />
- 툴 핵심 기능 조회
<img width="1052" alt="Screenshot 2025-01-12 at 1 40 34 AM" src="https://github.com/user-attachments/assets/d3a63dfd-68da-4902-ae4a-9595232b3c4d" />