### PR TITLE
Feat/#30 커스텀 어노테이션 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0'
 
+	//AOP 의존성 추가
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 
 
 	//aws 추가

--- a/src/main/java/com/daruda/darudaserver/domain/user/controller/KakaoController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/controller/KakaoController.java
@@ -8,6 +8,7 @@ import com.daruda.darudaserver.domain.user.dto.response.UserInfo;
 import com.daruda.darudaserver.domain.user.dto.response.kakao.KakaoTokenResponse;
 import com.daruda.darudaserver.domain.user.service.KakaoService;
 import com.daruda.darudaserver.domain.user.service.UserService;
+import com.daruda.darudaserver.global.auth.UserId;
 import com.daruda.darudaserver.global.common.response.ApiResponse;
 import com.daruda.darudaserver.global.error.code.SuccessCode;
 import jakarta.servlet.http.HttpServletResponse;
@@ -56,9 +57,9 @@ public class KakaoController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<?> logOut(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken){
-        Long userId = userService.deleteUser(accessToken);
-        return  ResponseEntity.ok(ApiResponse.ofSuccessWithData(userId,SuccessCode.SUCCESS_CREATE));
+    public ResponseEntity<?> logOut(@UserId Long userId){
+        Long returnedUserId = userService.deleteUser(userId);
+        return  ResponseEntity.ok(ApiResponse.ofSuccessWithData(returnedUserId,SuccessCode.SUCCESS_CREATE));
     }
 
     @PostMapping("/nickname")
@@ -68,7 +69,7 @@ public class KakaoController {
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<?> regenerateToken(@RequestHeader(HttpHeaders.AUTHORIZATION)String refreshToken){
+    public ResponseEntity<?> regenerateToken(@UserId String refreshToken){
         JwtTokenResponse jwtTokenResponse = userService.reissueToken(refreshToken);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(jwtTokenResponse,SuccessCode.SUCCESS_CREATE));
     }

--- a/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
@@ -77,13 +77,7 @@ public class UserService {
         return SignUpSuccessResponse.of(nickname,positions,email,jwtTokenResponse);
     }
 
-    public Long deleteUser(final String accessToken){
-        Long userId;
-        try{
-             userId= jwtTokenProvider.getUserIdFromJwt(accessToken);
-        } catch(JwtException e){
-            throw new BusinessException(ErrorCode.INVALID_FIELD_ERROR);
-        }
+    public Long deleteUser(final Long userId){
         tokenService.deleteRefreshToken(userId);
 
         return userId;

--- a/src/main/java/com/daruda/darudaserver/global/auth/UserId.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/UserId.java
@@ -1,0 +1,11 @@
+package com.daruda.darudaserver.global.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+}

--- a/src/main/java/com/daruda/darudaserver/global/auth/UserIdArgumentResolver.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/UserIdArgumentResolver.java
@@ -1,0 +1,26 @@
+package com.daruda.darudaserver.global.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter){
+        boolean hasUserIdAnnoation = parameter.hasParameterAnnotation(UserId.class);
+        boolean isLongType = Long.class.isAssignableFrom(parameter.getParameterType());
+        return hasUserIdAnnoation && isLongType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception{
+        return SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/global/config/WebConfig.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/WebConfig.java
@@ -1,11 +1,18 @@
 package com.daruda.darudaserver.global.config;
 
+import com.daruda.darudaserver.global.auth.UserIdArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+    private final UserIdArgumentResolver userIdArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry corsRegistry){
@@ -16,4 +23,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true) // 쿠키 인증 요청 허용
                 .maxAge(3000);
     }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers){
+        resolvers.add(userIdArgumentResolver);
+    }
+
 }


### PR DESCRIPTION
## 📣 Related Issue
- close #30 

## 📝 Summary
커스텀 어노테이션(@UserId) 구현 및 적용


## 🙏 Question & PR point

### 동작과정

![스크린샷 2025-01-13 000622.png](https://prod-files-secure.s3.us-west-2.amazonaws.com/fd6d73d7-9b8b-48e3-8216-6e5645d5a89e/96b0560d-c837-462a-9a91-00fe8fe27178/%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7_2025-01-13_000622.png)

1. 사용자 요청
2. DispatcherServlet 동작
3. 요청한 URI를 HandlerMapping에서 검색
4. SpringIntercepter 처리
5. ArgumentResolver 처리
6. MessageConverter처리

### Retention이란?

→Retention은 유지라는 뜻의 영단어인데 이름처럼 `@Retention`은 해당 어노테이션을 언제까지 유지할 것인지를 정의하는 부분이다

- `@Retention(RetentionPolicy.SOURCE)` : 컴파일러에 의해서 제거가 된다. 즉, 컴파일 전까지만 유지되는 어노테이션이다
- `@Rentention(RetentionPolicy.CLASS)` : 컴파일러에 의해 .class 파일에 기록되지만 JVM은 어노테이션을 유지하지 않는다
- `@Retention(RetentionPolicy.RUNTIME)` : 컴파일러에 의해 .class 파일에 기록되고 JVM에 의해서 어노테이션이 유지된다. 즉 Java로 작성한 코드가 돌아가는 동안엔 계속 유지된다.

### Target이란?

→ 어노테이션이 적용될 수 있는 대상을 정의할 수 있는 어노테이션이다.

- `@Target({ElementType.PARAMETER})` : 메서드의 파라미터에 붙일 수 있다. 클라이언트에서 전달 받은 API의 파라미터들에 자주 사용된다
- `@Target({ElementType.TYPE})` : 클래스, 인터페이서, Enum 또는 Record에 붙일 수 있다는 의미이다.
- `@Target({ElementType.FIELD})` : 변수에 붙일 수 있다는 의미이다.
- `@Target({ElementType.METHOD})` : 메서드에 붙일 수 있다는 의미이다.

### Argument Resolver

- API 엔드포인트로 인입된 데이터를 가공 및 바인딩 할 때 사용하는 객체이다
- Http Body 또는 파라미터로 넘어오는 데이터들은 다른 어노테이션으로 바인딩 할 수 있지만 헤더,쿠키, 세션 등으로 전달되는 데이터는 Argument Resolver를 이용할 수 있다
- 대표적인 예로 사용자의 정보를 얻거나 헤더로 전달되는 토큰에서 사용자의 정보를 얻을 때 사용한다

---

## 구현 코드

### AOP 의존성 추가

```java
implementation 'org.springframework.boot:spring-boot-starter-aop'
```

### UserId

```java
@Target(ElementType.PARAMETER)
@Retention(RetentionPolicy.RUNTIME)
public @interface UserId {
}
```

### UserIdArgumentResolver

```java
@Component
public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
    @Override
    public boolean supportsParameter(MethodParameter parameter){
        boolean hasUserIdAnnoation = parameter.hasParameterAnnotation(UserId.class);
        boolean isLongType = Long.class.isAssignableFrom(parameter.getParameterType());
        return hasUserIdAnnoation && isLongType;
    }

    @Override
    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception{
        return SecurityContextHolder.getContext()
                .getAuthentication()
                .getPrincipal();
    }
}

```

→UserId 어노테이션을 사용하기 위한 설정을 수행하는 Resolver이다

→파라미터 어노테이션을 사용하기 위한 조건 설정, 값, 설정 등을 수행하기 위해서 HandlerMethodArgumentResolver 인터페이스를 상속받는다

→@Component 필수!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

- **supportsParameter()**
    - 주어진 메소드의 파라미터가 이 ArgumentResolver에서 지원하는 타입인지 검사한다
- **resolveArgument()**
    - supportsParameter()가 true 값을 return하면 실행되는 메소드이다
    - 파라미터에 전달할 객체를 return 한다.

### WebConfig

```java
@Configuration
@RequiredArgsConstructor
public class WebConfig implements WebMvcConfigurer {
    private final UserIdArgumentResolver userIdArgumentResolver;

    @Override
    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers){
        resolvers.add(userIdArgumentResolver);
    }

}
```

→ ArgumentResolver를 Bean으로 등록할 수 있게끔한다.
