### PR TITLE
Feat/#41 내 정보 수정하기 API

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
@@ -65,6 +65,7 @@ public class Tool {
     @Column(name = "updated_at")
     private Timestamp updatedAt;
 
+
     // createdAt 값을 설정하는 메서드
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/daruda/darudaserver/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/controller/MyPageController.java
@@ -18,7 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/mypage")
+@RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class MyPageController {
     private final UserService userService;
@@ -41,5 +41,5 @@ public class MyPageController {
 
 
     }
- */
+*/
 }

--- a/src/main/java/com/daruda/darudaserver/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/controller/MyPageController.java
@@ -26,7 +26,7 @@ public class MyPageController {
     @PatchMapping
     public ResponseEntity<?> patchMy(@UserId Long userId,
                                      @Valid @RequestBody UpdateMyRequest updateMyRequest){
-        if(updateMyRequest.positions() ==null && updateMyRequest.positions() ==null){
+        if(updateMyRequest.positions() ==null && updateMyRequest.nickname() ==null){
             throw new BusinessException(ErrorCode.MISSING_PARAMETER);
         }
         UpdateMyResponse updateMyResponse = userService.updateMy(userId,updateMyRequest.nickname(),updateMyRequest.positions());
@@ -40,5 +40,6 @@ public class MyPageController {
         userService.getFavoriteTools(userId, pageNo, criteria);
 
 
-    }*/
+    }
+ */
 }

--- a/src/main/java/com/daruda/darudaserver/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/controller/MyPageController.java
@@ -1,0 +1,44 @@
+package com.daruda.darudaserver.domain.user.controller;
+
+import com.daruda.darudaserver.domain.user.dto.request.UpdateMyRequest;
+import com.daruda.darudaserver.domain.user.dto.response.UpdateMyResponse;
+import com.daruda.darudaserver.domain.user.service.UserService;
+import com.daruda.darudaserver.global.auth.UserId;
+import com.daruda.darudaserver.global.common.response.ApiResponse;
+import com.daruda.darudaserver.global.error.code.ErrorCode;
+import com.daruda.darudaserver.global.error.code.SuccessCode;
+import com.daruda.darudaserver.global.error.exception.BusinessException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+    private final UserService userService;
+
+    @PatchMapping
+    public ResponseEntity<?> patchMy(@UserId Long userId,
+                                     @Valid @RequestBody UpdateMyRequest updateMyRequest){
+        if(updateMyRequest.positions() ==null && updateMyRequest.positions() ==null){
+            throw new BusinessException(ErrorCode.MISSING_PARAMETER);
+        }
+        UpdateMyResponse updateMyResponse = userService.updateMy(userId,updateMyRequest.nickname(),updateMyRequest.positions());
+        return ResponseEntity.ok(ApiResponse.ofSuccessWithData(updateMyResponse, SuccessCode.SUCCESS_UPDATE));
+    }
+/*
+    @GetMapping("/tools")
+    public ResponseEntity<?> getFavoriteTools(@UserId Long userId,
+                                              @RequestParam(defaultValue = "1", value = "page")int pageNo,
+                                              @RequestParam(defaultValue = "createdAt", value = "criteria")String criteria){
+        userService.getFavoriteTools(userId, pageNo, criteria);
+
+
+    }*/
+}

--- a/src/main/java/com/daruda/darudaserver/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/dto/request/SignUpRequest.java
@@ -2,9 +2,13 @@ package com.daruda.darudaserver.domain.user.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 public record SignUpRequest(
         @NotNull(message = "닉네임은 필수 입력값입니다")
+        @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영어, 숫자만 허용됩니다.")
         String nickname,
 
         @NotNull(message = "소속은 필수 입력값입니다")

--- a/src/main/java/com/daruda/darudaserver/domain/user/dto/request/UpdateMyRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/dto/request/UpdateMyRequest.java
@@ -1,0 +1,15 @@
+package com.daruda.darudaserver.domain.user.dto.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateMyRequest(
+        @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영어, 숫자만 허용됩니다.")
+        String nickname,
+        @Nullable
+        String positions
+) {
+}

--- a/src/main/java/com/daruda/darudaserver/domain/user/dto/response/FavoriteToolsResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/dto/response/FavoriteToolsResponse.java
@@ -1,0 +1,4 @@
+package com.daruda.darudaserver.domain.user.dto.response;
+
+public record FavoriteToolsResponse() {
+}

--- a/src/main/java/com/daruda/darudaserver/domain/user/dto/response/UpdateMyResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/dto/response/UpdateMyResponse.java
@@ -1,0 +1,16 @@
+package com.daruda.darudaserver.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateMyResponse(
+        String nickname,
+        String positions
+) {
+    public static UpdateMyResponse of(String nickname, String positions){
+        return UpdateMyResponse.builder()
+                .nickname(nickname)
+                .positions(positions)
+                .build();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/entity/UserEntity.java
@@ -17,8 +17,8 @@ import lombok.NoArgsConstructor;
 public class UserEntity extends BaseTimeEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
-    private Long userId;
+    @Column(name = "id")
+    private Long id;
 
     @Column(nullable = false)
     private String email;
@@ -30,14 +30,19 @@ public class UserEntity extends BaseTimeEntity{
     @Column(nullable = false)
     private Positions positions;
 
-    @Column(nullable = false)
-    private SocialType socialType = SocialType.KAKAO;
 
     @Builder
-    private UserEntity(String email, String nickname, Positions positions, SocialType socialType){
+    private UserEntity(String email, String nickname, Positions positions){
         this.email = email;
         this.nickname = nickname;
         this.positions = positions;
-        this.socialType = socialType;
+    }
+
+    public void updatePositions(Positions positions){
+        this.positions = positions;
+    }
+
+    public void updateNickname(String nickname){
+        this.nickname=nickname;
     }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<UserEntity,Long> {
     Optional<UserEntity> findByEmail(String email);
     Boolean existsByNickname(String nickname);
+    Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
@@ -135,6 +135,9 @@ public class UserService {
     }
 
     public void getFavoriteTools(Long userId, int pageNo, String criteria){
+        userRepository.findById(userId)
+                .orElseThrow(()->new BusinessException(ErrorCode.USER_NOT_FOUND));
+
         Pageable pageable = PageRequest.of(pageNo,10, Sort.by(Sort.Direction.DESC, criteria));
     }
 

--- a/src/main/java/com/daruda/darudaserver/global/auth/jwt/entity/Token.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/jwt/entity/Token.java
@@ -1,5 +1,6 @@
 package com.daruda.darudaserver.global.auth.jwt.entity;
 
+import com.daruda.darudaserver.domain.user.entity.UserEntity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
@@ -16,12 +17,13 @@ public class Token {
     @Column(name = "refresh_token")
     private String refreshToken;
 
-    @Column(name = "user_id")
-    private Long userId;
+    @OneToOne(targetEntity = UserEntity.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity userEntity;
 
     @Builder
-    public Token(final Long userId, final String refreshToken) {
-        this.userId = userId;
+    public Token(UserEntity userEntity, String refreshToken) {
+        this.userEntity = userEntity;
         this.refreshToken = refreshToken;
     }
 

--- a/src/main/java/com/daruda/darudaserver/global/auth/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/jwt/provider/JwtTokenProvider.java
@@ -58,6 +58,7 @@ public class JwtTokenProvider {
         try {
             return Jwts.parserBuilder()
                     .setSigningKey(getSigningKey())
+                    .setAllowedClockSkewSeconds(60)
                     .build()
                     .parseClaimsJws(token)
                     .getBody();

--- a/src/main/java/com/daruda/darudaserver/global/auth/jwt/repository/TokenRepository.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/jwt/repository/TokenRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface TokenRepository extends CrudRepository<Token, Long> {
     Optional<Token> findByRefreshToken(final String refreshToken);
 
-    Optional<Token> findByUserId(final Long userId);
+    Optional<Token> findByUserEntityId(final Long userId);
 }

--- a/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
@@ -1,5 +1,6 @@
 package com.daruda.darudaserver.global.auth.jwt.service;
 
+import com.daruda.darudaserver.domain.user.entity.UserEntity;
 import com.daruda.darudaserver.global.auth.jwt.entity.Token;
 import com.daruda.darudaserver.global.auth.jwt.repository.TokenRepository;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
@@ -18,9 +19,9 @@ public class TokenService {
 
 
     @Transactional
-    public void saveRefreshtoken(final Long userId, final String refreshToken){
+    public void saveRefreshtoken(final UserEntity userEntity, final String refreshToken){
         tokenRepository.save(Token.builder()
-                .userId(userId)
+                .userEntity(userEntity)
                 .refreshToken(refreshToken)
                 .build());
     }
@@ -29,12 +30,14 @@ public class TokenService {
     public Long findIdByRefreshToken(final String refreshToken){
         Token token = tokenRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new InvalidValueException(ErrorCode.REFRESH_TOKEN_EMPTY_ERROR));
-        return token.getUserId();
+        UserEntity userEntity = token.getUserEntity();
+        Long userId = userEntity.getId();
+        return userId;
     }
 
     @Transactional
     public void deleteRefreshToken(final Long userId){
-        Token token = tokenRepository.findByUserId(userId)
+        Token token = tokenRepository.findByUserEntityId(userId)
                 .orElseThrow(()-> new NotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
         tokenRepository.delete(token);
@@ -43,11 +46,9 @@ public class TokenService {
     @Transactional
     public String getRefreshTokenByUserId(Long userId)
     {
-        Token token = tokenRepository.findByUserId(userId)
+        Token token = tokenRepository.findByUserEntityId(userId)
                 .orElseThrow(()->new NotFoundException(ErrorCode.USER_NOT_FOUND));
-
-        String refreshToken = token.getRefreshToken();
-        return refreshToken;
+        return token.getRefreshToken();
     }
 
 }

--- a/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
+++ b/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
@@ -38,6 +38,10 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "E404002", "유저가 존재하지 않습니다"),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND,"E404003", "리프레쉬 토큰이 존재하지 않습니다"),
 
+    /* 409 CONFLICT */
+    DUPLICATED_NICKNAME(HttpStatus.CONFLICT,"E409001","닉네임 중복입니다"),
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT,"E409002","이메일 중복입니다"),
+
     /* 500 INTERNAL SERVER ERROR */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500001","서버 내부에서 오류가 발생했습니다"),
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E500002", "이미지 업로드에 실패했습니다"),

--- a/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolServiceTest.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.when;
                     .email("test@example.com")
                     .nickname("tester")
                     .positions(null)
-                    .socialType(null)
                     .build();
 
             when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));


### PR DESCRIPTION
## 📣 Related Issue
내 정보 수정하기 API
- close #41 

## 📝 Summary

1. UserEntity와 Token을 일대일 관계로 연관관계를 맺어주었습니다
2. UpdatemyRequest에서 닉네임이 10자를 넘으면 안 되고 특수문자가 들어가면 안 되도록 validation을 추가하였습니다
3. 회원가입시 email 중복 검사하도록 로직을 추가해주었습니다
## 📬 Postman
![스크린샷 2025-01-14 223739](https://github.com/user-attachments/assets/22bcdc1b-f075-4ba8-bd9a-c6622c504a18)

