### PR TITLE
Feat/#51 댓글 작성 API

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/comments")
@@ -20,7 +22,7 @@ public class CommentController {
     @PostMapping
     public ResponseEntity<?> postComment(@UserId Long userId,
                                          @PathVariable("board-id")Long boardId,
-                                         @Valid @RequestBody CreateCommentRequest createCommentRequest){
+                                         @Valid @RequestBody CreateCommentRequest createCommentRequest) throws IOException {
         CreateCommentResponse createCommentResponse = commentService.postComment(userId, boardId, createCommentRequest);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(createCommentResponse, SuccessCode.SUCCESS_CREATE));
     }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
@@ -7,6 +7,7 @@ import com.daruda.darudaserver.global.common.response.ApiResponse;
 import com.daruda.darudaserver.global.error.code.SuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,6 +23,13 @@ public class CommentController {
                                          @Valid @RequestBody CreateCommentRequest createCommentRequest){
         CreateCommentResponse createCommentResponse = commentService.postComment(userId, boardId, createCommentRequest);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(createCommentResponse, SuccessCode.SUCCESS_CREATE));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<?> deleteComment(@UserId Long userId,
+                                           @RequestParam("comment-id")Long commentId){
+        commentService.deleteComment(userId, commentId);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(SuccessCode.SUCCESS_DELETE));
     }
 
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
@@ -5,11 +5,13 @@ import com.daruda.darudaserver.domain.comment.service.CommentService;
 import com.daruda.darudaserver.global.auth.UserId;
 import com.daruda.darudaserver.global.common.response.ApiResponse;
 import com.daruda.darudaserver.global.error.code.SuccessCode;
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
@@ -21,9 +23,10 @@ public class CommentController {
 
     @PostMapping
     public ResponseEntity<?> postComment(@UserId Long userId,
-                                         @PathVariable("board-id")Long boardId,
-                                         @Valid @RequestBody CreateCommentRequest createCommentRequest) throws IOException {
-        CreateCommentResponse createCommentResponse = commentService.postComment(userId, boardId, createCommentRequest);
+                                         @RequestParam("board-id")Long boardId,
+                                         @Valid @ModelAttribute CreateCommentRequest createCommentRequest,
+                                         @Nullable @RequestPart(value = "image", required = false)MultipartFile image) throws IOException {
+        CreateCommentResponse createCommentResponse = commentService.postComment(userId, boardId, createCommentRequest, image);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(createCommentResponse, SuccessCode.SUCCESS_CREATE));
     }
 

--- a/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
@@ -19,7 +19,7 @@ public class CommentController {
 
     @PostMapping
     public ResponseEntity<?> postComment(@UserId Long userId,
-                                         @RequestParam("board-id")Long boardId,
+                                         @PathVariable("board-id")Long boardId,
                                          @Valid @RequestBody CreateCommentRequest createCommentRequest){
         CreateCommentResponse createCommentResponse = commentService.postComment(userId, boardId, createCommentRequest);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(createCommentResponse, SuccessCode.SUCCESS_CREATE));
@@ -27,7 +27,7 @@ public class CommentController {
 
     @DeleteMapping
     public ResponseEntity<?> deleteComment(@UserId Long userId,
-                                           @RequestParam("comment-id")Long commentId){
+                                           @PathVariable("comment-id")Long commentId){
         commentService.deleteComment(userId, commentId);
         return ResponseEntity.ok(ApiResponse.ofSuccess(SuccessCode.SUCCESS_DELETE));
     }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
@@ -1,0 +1,27 @@
+package com.daruda.darudaserver.domain.comment.controller;
+import com.daruda.darudaserver.domain.comment.dto.request.CreateCommentRequest;
+import com.daruda.darudaserver.domain.comment.dto.response.CreateCommentResponse;
+import com.daruda.darudaserver.domain.comment.service.CommentService;
+import com.daruda.darudaserver.global.auth.UserId;
+import com.daruda.darudaserver.global.common.response.ApiResponse;
+import com.daruda.darudaserver.global.error.code.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/comments")
+public class CommentController {
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<?> postComment(@UserId Long userId,
+                                         @RequestParam("board-id")Long boardId,
+                                         @Valid @RequestBody CreateCommentRequest createCommentRequest){
+        CreateCommentResponse createCommentResponse = commentService.postComment(userId, boardId, createCommentRequest);
+        return ResponseEntity.ok(ApiResponse.ofSuccessWithData(createCommentResponse, SuccessCode.SUCCESS_CREATE));
+    }
+
+}

--- a/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
@@ -32,9 +32,8 @@ public class CommentController {
 
     @DeleteMapping
     public ResponseEntity<?> deleteComment(@UserId Long userId,
-                                           @PathVariable("comment-id")Long commentId){
+                                           @RequestParam("comment-id")Long commentId){
         commentService.deleteComment(userId, commentId);
         return ResponseEntity.ok(ApiResponse.ofSuccess(SuccessCode.SUCCESS_DELETE));
     }
-
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/dto/request/CreateCommentRequest.java
@@ -1,0 +1,13 @@
+package com.daruda.darudaserver.domain.comment.dto.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateCommentRequest(
+        @Size(min = 0,max = 1000, message = "글자 수는 1자 이상 1000자 이하여야 합니다")
+        String content,
+        @Nullable
+        String image
+) {
+}

--- a/src/main/java/com/daruda/darudaserver/domain/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/dto/request/CreateCommentRequest.java
@@ -7,8 +7,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 public record CreateCommentRequest(
         @Size(min = 1,max = 1000, message = "글자 수는 1자 이상 1000자 이하여야 합니다")
-        String content,
-        @Nullable
-        MultipartFile image
+        String content
 ) {
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/dto/request/CreateCommentRequest.java
@@ -3,11 +3,12 @@ package com.daruda.darudaserver.domain.comment.dto.request;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
 
 public record CreateCommentRequest(
-        @Size(min = 0,max = 1000, message = "글자 수는 1자 이상 1000자 이하여야 합니다")
+        @Size(min = 1,max = 1000, message = "글자 수는 1자 이상 1000자 이하여야 합니다")
         String content,
         @Nullable
-        String image
+        MultipartFile image
 ) {
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/dto/response/CreateCommentResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/dto/response/CreateCommentResponse.java
@@ -1,0 +1,26 @@
+package com.daruda.darudaserver.domain.comment.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+import java.sql.Timestamp;
+
+@Builder
+public record CreateCommentResponse(
+        Long commentId,
+        String content,
+        @JsonFormat(shape=JsonFormat.Shape.STRING,pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
+        Timestamp updatedAt,
+        String image,
+        String nickname
+) {
+    public static CreateCommentResponse of(Long commentId, String content,Timestamp updatedAt, String image, String nickname){
+        return CreateCommentResponse.builder()
+                .commentId(commentId)
+                .content(content)
+                .updatedAt(updatedAt)
+                .image(image)
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/entity/CommentEntity.java
@@ -1,0 +1,40 @@
+package com.daruda.darudaserver.domain.comment.entity;
+
+import com.daruda.darudaserver.domain.community.entity.Board;
+import com.daruda.darudaserver.domain.user.entity.UserEntity;
+import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Table(name = "comment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CommentEntity extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "comment_photo_url", nullable = true)
+    private String photoUrl;
+
+    @ManyToOne(targetEntity = UserEntity.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity userEntity;
+
+    @ManyToOne(targetEntity = Board.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @Builder
+    public CommentEntity(String content, String photoUrl, UserEntity userEntity, Board board){
+        this.content = content;
+        this.photoUrl = photoUrl;
+        this.board = board;
+        this.userEntity = userEntity;
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.daruda.darudaserver.domain.comment.repository;
+
+import com.daruda.darudaserver.domain.comment.entity.CommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<CommentEntity,Long> {
+}

--- a/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
@@ -2,6 +2,8 @@ package com.daruda.darudaserver.domain.comment.repository;
 
 import com.daruda.darudaserver.domain.comment.entity.CommentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CommentRepository extends JpaRepository<CommentEntity,Long> {
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
@@ -13,6 +13,7 @@ import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.BadRequestException;
 import com.daruda.darudaserver.global.error.exception.BusinessException;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
+import com.daruda.darudaserver.global.image.service.ImageService;
 import com.daruda.darudaserver.global.infra.S3.S3Service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class CommentService {
     private final BoardRepository boardRepository;
     private final UserRepository userRepository;
     private final S3Service s3Service;
+    private final ImageService imageService;
 
     public CreateCommentResponse postComment(Long userId, Long boardId, CreateCommentRequest createCommentRequest) throws IOException {
         //게시글과 사용자 존재 여부 검사

--- a/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
@@ -8,6 +8,7 @@ import com.daruda.darudaserver.domain.community.entity.Board;
 import com.daruda.darudaserver.domain.community.repository.BoardRepository;
 import com.daruda.darudaserver.domain.user.entity.UserEntity;
 import com.daruda.darudaserver.domain.user.repository.UserRepository;
+import com.daruda.darudaserver.domain.user.service.UserService;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
 import jakarta.transaction.Transactional;
@@ -45,4 +46,17 @@ public class CommentService {
 
         return createCommentResponse;
     }
+
+    public void deleteComment(Long userId, Long commentId){
+        //사용자 존재 여부 검사
+        userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+        //댓글 존재 여부 검사 및 entity 반환
+        CommentEntity commentEntity = commentRepository.findById(commentId)
+                .orElseThrow(()-> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+        //댓글 삭제
+        commentRepository.delete(commentEntity);
+    }
+
+
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
@@ -1,0 +1,46 @@
+package com.daruda.darudaserver.domain.comment.service;
+
+import com.daruda.darudaserver.domain.comment.dto.request.CreateCommentRequest;
+import com.daruda.darudaserver.domain.comment.dto.response.CreateCommentResponse;
+import com.daruda.darudaserver.domain.comment.entity.CommentEntity;
+import com.daruda.darudaserver.domain.comment.repository.CommentRepository;
+import com.daruda.darudaserver.domain.community.entity.Board;
+import com.daruda.darudaserver.domain.community.repository.BoardRepository;
+import com.daruda.darudaserver.domain.user.entity.UserEntity;
+import com.daruda.darudaserver.domain.user.repository.UserRepository;
+import com.daruda.darudaserver.global.error.code.ErrorCode;
+import com.daruda.darudaserver.global.error.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+
+    public CreateCommentResponse postComment(Long userId, Long boardId, CreateCommentRequest createCommentRequest){
+        //게시글과 사용자 존재 여부 검사
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(()->new NotFoundException(ErrorCode.DATA_NOT_FOUND));
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(()->new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        //댓글 entity 생성
+        CommentEntity commentEntity = CommentEntity.builder()
+                .userEntity(userEntity)
+                .board(board)
+                .photoUrl(createCommentRequest.image())
+                .content(createCommentRequest.content())
+                .build();
+
+        //댓글 entity 생성 및 댓글 ID 추출
+        Long commentId = commentRepository.save(commentEntity).getId();
+
+        //ResponseDto 변환
+        CreateCommentResponse createCommentResponse = CreateCommentResponse.of(commentId, commentEntity.getContent(), commentEntity.getUpdatedAt(),commentEntity.getPhotoUrl(),userEntity.getNickname());
+
+        return createCommentResponse;
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
@@ -10,11 +10,13 @@ import com.daruda.darudaserver.domain.user.entity.UserEntity;
 import com.daruda.darudaserver.domain.user.repository.UserRepository;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CommentService {
     private final CommentRepository commentRepository;
     private final BoardRepository boardRepository;

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardRepository.java
@@ -1,9 +1,14 @@
 package com.daruda.darudaserver.domain.community.repository;
 
 import com.daruda.darudaserver.domain.community.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface BoardRepository extends JpaRepository<Board,Long> {
+    Page<Board> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
+++ b/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "E404001","데이터가 존재하지 않습니다"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "E404002", "유저가 존재하지 않습니다"),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND,"E404003", "리프레쉬 토큰이 존재하지 않습니다"),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND,"E404004","댓글이 존재하지 않습니다"),
 
     /* 409 CONFLICT */
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT,"E409001","닉네임 중복입니다"),

--- a/src/main/java/com/daruda/darudaserver/global/infra/S3/S3Service.java
+++ b/src/main/java/com/daruda/darudaserver/global/infra/S3/S3Service.java
@@ -94,7 +94,7 @@ public class S3Service {
         }
     }
 
-    private String getImageUrl(String imageName) {
+    public String getImageUrl(String imageName) {
         return String.format("https://%s.s3.amazonaws.com/%s", bucketName, imageName); // S3의 퍼블릭 URL 생성
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
- close #51

## 📝 Summary

1. Comment Entity와 UserEntity 일대다 관계 매핑
2. CommentEntity와 Board 일대다 관계 매핑
3. 댓글 작성 API 구현
4. 댓글 삭제 API 구현

## 🙏 Question & PR point
기존 ERD는 댓글과 댓글사진을 일대다 관계로 매핑하였지만 댓글이 사진 하나만 올릴 수 있어서 댓글 Entity의 필드에 댓글 사진 URL을 추가하였습니다


## 📬 Postman
![스크린샷 2025-01-15 170502](https://github.com/user-attachments/assets/c38eb06f-84df-43fb-82e1-049756c4c4bc)
![스크린샷 2025-01-15 172041](https://github.com/user-attachments/assets/9df43641-2b5b-481b-a517-9ac6abf2eba6)


