### PR TITLE
[Feat] 게시글 리스트 조회

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
@@ -3,8 +3,10 @@ package com.daruda.darudaserver.domain.community.controller;
 import com.daruda.darudaserver.domain.community.dto.req.BoardCreateAndUpdateReq;
 import com.daruda.darudaserver.domain.community.dto.res.BoardRes;
 import com.daruda.darudaserver.domain.community.dto.res.BoardScrapRes;
+import com.daruda.darudaserver.domain.community.dto.res.GetBoardResponse;
 import com.daruda.darudaserver.domain.community.service.BoardService;
 import com.daruda.darudaserver.domain.tool.dto.res.ToolScrapRes;
+import com.daruda.darudaserver.domain.tool.entity.Category;
 import com.daruda.darudaserver.domain.tool.service.ToolService;
 import com.daruda.darudaserver.global.auth.UserId;
 import com.daruda.darudaserver.global.common.response.ApiResponse;
@@ -83,4 +85,13 @@ public class BoardController {
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(boardScrapRes , SuccessCode.SUCCESS_SCRAP));
     }
 
+    @GetMapping("boards/board/list")
+    public ResponseEntity <ApiResponse<?>> getBoardList(
+            @RequestParam(name = "toolId",required = false) Long toolId,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "lastBoardId", required = false) Long lastBoardId )
+    {// 마지막 게시물 ID
+        GetBoardResponse boardResponse =  boardService.getBoardList(toolId, size, lastBoardId);
+        return ResponseEntity.ok(ApiResponse.ofSuccessWithData(boardResponse, SuccessCode.SUCCESS_FETCH));
+    }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
@@ -83,8 +83,4 @@ public class BoardController {
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(boardScrapRes , SuccessCode.SUCCESS_SCRAP));
     }
 
-    @GetMapping("/board/list")
-    public ResponseEntity<ApiResponse<?>> getBoards(){
-
-    }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
@@ -5,8 +5,6 @@ import com.daruda.darudaserver.domain.community.dto.res.BoardRes;
 import com.daruda.darudaserver.domain.community.dto.res.BoardScrapRes;
 import com.daruda.darudaserver.domain.community.dto.res.GetBoardResponse;
 import com.daruda.darudaserver.domain.community.service.BoardService;
-import com.daruda.darudaserver.domain.tool.dto.res.ToolScrapRes;
-import com.daruda.darudaserver.domain.tool.entity.Category;
 import com.daruda.darudaserver.domain.tool.service.ToolService;
 import com.daruda.darudaserver.global.auth.UserId;
 import com.daruda.darudaserver.global.common.response.ApiResponse;
@@ -85,12 +83,15 @@ public class BoardController {
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(boardScrapRes , SuccessCode.SUCCESS_SCRAP));
     }
 
+    /**
+     * 게시글 리스트 조회
+     */
     @GetMapping("boards/board/list")
     public ResponseEntity <ApiResponse<?>> getBoardList(
             @RequestParam(name = "toolId",required = false) Long toolId,
             @RequestParam(value = "size", defaultValue = "10") int size,
             @RequestParam(value = "lastBoardId", required = false) Long lastBoardId )
-    {// 마지막 게시물 ID
+    {
         GetBoardResponse boardResponse =  boardService.getBoardList(toolId, size, lastBoardId);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(boardResponse, SuccessCode.SUCCESS_FETCH));
     }

--- a/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
@@ -82,4 +82,9 @@ public class BoardController {
         BoardScrapRes boardScrapRes = boardService.postScrap(userId,boardId);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(boardScrapRes , SuccessCode.SUCCESS_SCRAP));
     }
+
+    @GetMapping("/board/list")
+    public ResponseEntity<ApiResponse<?>> getBoards(){
+
+    }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/dto/req/BoardCreateAndUpdateReq.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/dto/req/BoardCreateAndUpdateReq.java
@@ -12,7 +12,7 @@ public record BoardCreateAndUpdateReq(
         @NotNull(message="내용  입력은 필수 입니다.")
         String content,
         Long toolId,
-        @NotNull(message = "자유게시판 선택은 필수 입니다")
+        @NotNull(message = "자유 게시판 선택은 필수 입니다")
         boolean isFree// 자유 게시판 여부 추가
 ) {
         public static BoardCreateAndUpdateReq of(String title, String content, Long toolId, boolean isFree) {

--- a/src/main/java/com/daruda/darudaserver/domain/community/dto/res/BoardRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/dto/res/BoardRes.java
@@ -1,6 +1,7 @@
 package com.daruda.darudaserver.domain.community.dto.res;
 
 import com.daruda.darudaserver.domain.community.entity.Board;
+import com.daruda.darudaserver.domain.tool.entity.Tool;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,32 +13,43 @@ import java.util.List;
 @Builder(access = AccessLevel.PRIVATE)
 public record BoardRes(
         Long boardId,
-        Long toolId,
+        String toolName,
+        String toolLogo,
+        String author,
         String title,
         String content,
         List<String> images,
         @JsonFormat(shape=JsonFormat.Shape.STRING,pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
-        Timestamp updatedAt
+        Timestamp updatedAt,
+        int commentCount
 ) {
-    public static BoardRes of(final Board board,final List<String> images){
+    // Image 가 있는 경우
+    public static BoardRes of(final Board board,final String toolName, final String toolLogo,  final int commentCount,final List<String> images ){
         return BoardRes.builder()
                 .boardId(board.getBoardId())
-                .toolId(board.getToolId())
+                .toolName(toolName)
+                .toolLogo(toolLogo)
+                .author(board.getUser().getNickname())
                 .title(board.getTitle())
                 .content(board.getContent())
                 .images(images)
                 .updatedAt(board.getUpdatedAt())
+                .commentCount(commentCount)
                 .build();
     }
 
-    public static BoardRes of(final Board board){
+    //Image 가 없는 경우
+    public static BoardRes of(final Board board, final String toolName, final String toolLogo,final int commentCount){
         return BoardRes.builder()
                 .boardId(board.getBoardId())
-                .toolId(board.getToolId())
+                .toolName(toolName)
+                .toolLogo(toolLogo)
+                .author(board.getUser().getNickname())
                 .title(board.getTitle())
                 .content(board.getContent())
-                .updatedAt(board.getUpdatedAt())
                 .images(null)
+                .updatedAt(board.getUpdatedAt())
+                .commentCount(commentCount)
                 .build();
     }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/dto/res/BoardRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/dto/res/BoardRes.java
@@ -1,30 +1,34 @@
 package com.daruda.darudaserver.domain.community.dto.res;
 
 import com.daruda.darudaserver.domain.community.entity.Board;
-import com.daruda.darudaserver.domain.tool.entity.Tool;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.sql.Timestamp;
 import java.util.List;
 
 //Private 로 하는 이유
-@Builder(access = AccessLevel.PRIVATE)
-public record BoardRes(
-        Long boardId,
-        String toolName,
-        String toolLogo,
-        String author,
-        String title,
-        String content,
-        List<String> images,
-        @JsonFormat(shape=JsonFormat.Shape.STRING,pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
-        Timestamp updatedAt,
-        int commentCount
-) {
-    // Image 가 있는 경우
-    public static BoardRes of(final Board board,final String toolName, final String toolLogo,  final int commentCount,final List<String> images ){
+@Builder
+@Getter
+public class BoardRes {
+    private Long boardId;
+    private String toolName;
+    private String toolLogo;
+    private String author;
+    private String title;
+    private String content;
+    private List<String> images;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
+    private Timestamp updatedAt;
+    private int commentCount;
+
+    public static BoardRes of(final Board board, final String toolName, final String toolLogo, final int commentCount, final List<String> images) {
+        return createBoardRes(board, toolName, toolLogo, commentCount, images);
+    }
+
+    public static BoardRes createBoardRes(final Board board, final String toolName, final String toolLogo, final int commentCount, final List<String> images) {
         return BoardRes.builder()
                 .boardId(board.getBoardId())
                 .toolName(toolName)
@@ -33,21 +37,6 @@ public record BoardRes(
                 .title(board.getTitle())
                 .content(board.getContent())
                 .images(images)
-                .updatedAt(board.getUpdatedAt())
-                .commentCount(commentCount)
-                .build();
-    }
-
-    //Image 가 없는 경우
-    public static BoardRes of(final Board board, final String toolName, final String toolLogo,final int commentCount){
-        return BoardRes.builder()
-                .boardId(board.getBoardId())
-                .toolName(toolName)
-                .toolLogo(toolLogo)
-                .author(board.getUser().getNickname())
-                .title(board.getTitle())
-                .content(board.getContent())
-                .images(null)
                 .updatedAt(board.getUpdatedAt())
                 .commentCount(commentCount)
                 .build();

--- a/src/main/java/com/daruda/darudaserver/domain/community/dto/res/GetBoardResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/dto/res/GetBoardResponse.java
@@ -1,0 +1,42 @@
+package com.daruda.darudaserver.domain.community.dto.res;
+
+import com.daruda.darudaserver.domain.community.entity.Board;
+import com.daruda.darudaserver.global.common.response.ScrollPaginationCollection;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class GetBoardResponse {
+    private static final long LAST_CURSOR = -1L;
+    private List<BoardRes> contents;
+    private long totalElements;
+    private long nextCursor;
+
+    public GetBoardResponse(List<BoardRes> contents, long totalElements, long nextCursor) {
+        this.contents = contents;
+        this.totalElements = totalElements;
+        this.nextCursor = nextCursor;
+    }
+
+    public static GetBoardResponse of (ScrollPaginationCollection<Board> pagination, String toolName, String toolLogo, int commentCount, List<String> boardImages){
+        List<BoardRes> boardResList = pagination.getCurrentScrollItems().stream().map(board -> BoardRes.of(
+                        board,
+                        toolName,
+                        toolLogo,
+                        commentCount,
+                        boardImages
+                ))
+                .collect(Collectors.toList());
+
+        long nextCursor = pagination.isLastScroll() ? LAST_CURSOR : pagination.getNextCursor().getBoardId();
+
+        return new GetBoardResponse(boardResList, pagination.getTotalElements(), nextCursor);
+    }
+}
+

--- a/src/main/java/com/daruda/darudaserver/domain/community/entity/Board.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/entity/Board.java
@@ -6,6 +6,7 @@ import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.BadRequestException;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -30,12 +31,12 @@ public class Board extends BaseTimeEntity {
     @Builder.Default
     private boolean delYn = false;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="tool_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tool_id", unique = false)
     private Tool tool;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="user_id",nullable = false)
+    @JoinColumn(name="user_id",nullable = false,unique = false)
     private UserEntity user;
 
     @Builder.Default

--- a/src/main/java/com/daruda/darudaserver/domain/community/entity/Board.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/entity/Board.java
@@ -1,5 +1,6 @@
 package com.daruda.darudaserver.domain.community.entity;
 
+import com.daruda.darudaserver.domain.tool.entity.Tool;
 import com.daruda.darudaserver.domain.user.entity.UserEntity;
 import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
@@ -7,7 +8,6 @@ import com.daruda.darudaserver.global.error.exception.BadRequestException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-import org.springframework.lang.Nullable;;
 
 @Getter
 @Entity
@@ -30,8 +30,9 @@ public class Board extends BaseTimeEntity {
     @Builder.Default
     private boolean delYn = false;
 
-    @Column(name="tool_id",nullable = true)
-    private Long toolId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="tool_id")
+    private Tool tool;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id",nullable = false)
@@ -41,22 +42,21 @@ public class Board extends BaseTimeEntity {
     private boolean isFree=true;
 
     @Builder
-    public Board(final String title,final String content, final Long toolId, final UserEntity user, final boolean delYn,final boolean isFree) {
+    public Board(final String title,final String content, final Tool tool, final UserEntity user, final boolean delYn,final boolean isFree) {
         this.title = title;
         this.content = content;
-        this.toolId = toolId;
+        this.tool = tool;
         this.user = user;
         this.delYn = delYn;
         this.isFree = isFree;
     }
 
-    public static Board create(final Long toolId, final UserEntity user, final String title, final String content){
-        if (toolId == null) {
+    public static Board create(final Tool tool, final UserEntity user, final String title, final String content){
+        if (tool == null) {
             throw new BadRequestException(ErrorCode.BAD_REQUEST_DATA);
-
         }
         return Board.builder()
-                .toolId(toolId)
+                .tool(tool)
                 .user(user)
                 .title(title)
                 .content(content)
@@ -66,7 +66,7 @@ public class Board extends BaseTimeEntity {
 
     public static Board createFree( final UserEntity user, final String title, final String content){
         return Board.builder()
-                .toolId(null)
+                .tool(null)
                 .user(user)
                 .title(title)
                 .content(content)
@@ -74,8 +74,8 @@ public class Board extends BaseTimeEntity {
                 .build();
     }
 
-    public void update(final Long toolId, final UserEntity user, final String title, final String content, final boolean isFree) {
-        this.toolId = toolId;
+    public void update(final Tool tool, final UserEntity user, final String title, final String content, final boolean isFree) {
+        this.tool = tool;
         this.user = user;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/daruda/darudaserver/domain/community/entity/Board.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/entity/Board.java
@@ -6,7 +6,8 @@ import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.BadRequestException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;;
+import lombok.*;
+import org.springframework.lang.Nullable;;
 
 @Getter
 @Entity
@@ -29,6 +30,7 @@ public class Board extends BaseTimeEntity {
     @Builder.Default
     private boolean delYn = false;
 
+    @Column(name="tool_id",nullable = true)
     private Long toolId;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -36,7 +38,7 @@ public class Board extends BaseTimeEntity {
     private UserEntity user;
 
     @Builder.Default
-    private boolean isFree=false;
+    private boolean isFree=true;
 
     @Builder
     public Board(final String title,final String content, final Long toolId, final UserEntity user, final boolean delYn,final boolean isFree) {
@@ -72,13 +74,13 @@ public class Board extends BaseTimeEntity {
                 .build();
     }
 
-    public void update(final Long toolId, final UserEntity user, final String title, final String content) {
+    public void update(final Long toolId, final UserEntity user, final String title, final String content, final boolean isFree) {
         this.toolId = toolId;
         this.user = user;
         this.title = title;
         this.content = content;
+        this.isFree = isFree;
     }
-
 
     public void delete(){
         this.delYn=true;

--- a/src/main/java/com/daruda/darudaserver/domain/community/entity/BoardScrap.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/entity/BoardScrap.java
@@ -1,7 +1,9 @@
 package com.daruda.darudaserver.domain.community.entity;
 
 import com.daruda.darudaserver.domain.user.entity.UserEntity;
+import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -9,7 +11,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
-public class BoardScrap {
+public class BoardScrap extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,4 +25,11 @@ public class BoardScrap {
     @JoinColumn(name="user_id",nullable = false)
     private UserEntity user;
 
+    @NotNull
+    @Builder.Default
+    private boolean delYn = false;
+
+    public void update() {
+        this.delYn = !this.delYn;
+    }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardImageRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardImageRepository.java
@@ -3,12 +3,9 @@ package com.daruda.darudaserver.domain.community.repository;
 import com.daruda.darudaserver.domain.community.entity.BoardImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.Collection;
 import java.util.List;
 
 @Repository
 public interface BoardImageRepository extends JpaRepository<BoardImage,Long> {
-
     List<BoardImage> findAllByBoardId(Long boardId);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardRepository.java
@@ -1,16 +1,12 @@
 package com.daruda.darudaserver.domain.community.repository;
 
 import com.daruda.darudaserver.domain.community.entity.Board;
-import com.daruda.darudaserver.domain.tool.entity.Category;
 import com.daruda.darudaserver.domain.tool.entity.Tool;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardRepository.java
@@ -1,14 +1,30 @@
 package com.daruda.darudaserver.domain.community.repository;
 
 import com.daruda.darudaserver.domain.community.entity.Board;
+import com.daruda.darudaserver.domain.tool.entity.Category;
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 import java.util.Optional;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board,Long> {
+
+    List<Board> findByToolAndBoardIdLessThanOrderByBoardIdDesc(Tool tool, Long cursor, Pageable pageable);
+
+    List<Board> findByIsFreeAndBoardIdLessThanOrderByBoardIdDesc(
+            boolean isFree, Long boardId, Pageable pageable);
+
+    List<Board> findByBoardIdLessThanOrderByBoardIdDesc(Long cursor, PageRequest pageRequest);
     Page<Board> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardScrapRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardScrapRepository.java
@@ -10,7 +10,5 @@ import java.util.Optional;
 
 @Repository
 public interface BoardScrapRepository extends JpaRepository<BoardScrap,Long> {
-
-
     Optional<BoardScrap> findByUserAndBoard(UserEntity user, Board board);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardScrapRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardScrapRepository.java
@@ -6,10 +6,11 @@ import com.daruda.darudaserver.domain.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface BoardScrapRepository extends JpaRepository<BoardScrap,Long> {
 
-    void deleteByUserAndBoard(UserEntity user, Board board);
 
-    boolean existsByUserAndBoard(UserEntity user, Board board);
+    Optional<BoardScrap> findByUserAndBoard(UserEntity user, Board board);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -10,7 +10,6 @@ import com.daruda.darudaserver.domain.community.entity.BoardScrap;
 import com.daruda.darudaserver.domain.community.repository.BoardImageRepository;
 import com.daruda.darudaserver.domain.community.repository.BoardRepository;
 import com.daruda.darudaserver.domain.community.repository.BoardScrapRepository;
-import com.daruda.darudaserver.domain.tool.entity.Category;
 import com.daruda.darudaserver.domain.tool.entity.Tool;
 import com.daruda.darudaserver.domain.tool.repository.ToolRepository;
 import com.daruda.darudaserver.domain.user.entity.UserEntity;
@@ -69,7 +68,6 @@ public class BoardService {
         Board board = validateBoardAndUser(userId, boardId);
         Tool tool = getToolById(boardCreateAndUpdateReq.toolId());
         board.update(
-
                 tool,
                 board.getUser(),
                 boardCreateAndUpdateReq.title(),

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -58,7 +58,7 @@ public class BoardService {
         List<String> imageUrls = processImages(board, images);
 
         // Tool 정보 설정
-        String toolName = board.getTool() != null ? board.getTool().getToolMainName() : "자유";
+        String toolName = board.getTool() != null ? board.getTool().getToolMainName() : FREE;
         String toolLogo = board.getTool() != null ? board.getTool().getToolLogo() : TOOL_LOGO;
 
         return BoardRes.of(board, toolName, toolLogo, getCommentCount(board.getBoardId()), imageUrls);

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
@@ -1,13 +1,10 @@
 package com.daruda.darudaserver.domain.tool.entity;
 
-import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
-import jakarta.annotation.Nullable;
+
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.sql.Timestamp;
-import java.util.List;
 
 @Entity
 @Table(name="tool")
@@ -64,7 +61,6 @@ public class Tool {
 
     @Column(name = "updated_at")
     private Timestamp updatedAt;
-
 
     // createdAt 값을 설정하는 메서드
     @PrePersist

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolScrap.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolScrap.java
@@ -1,18 +1,18 @@
 package com.daruda.darudaserver.domain.tool.entity;
 
 import com.daruda.darudaserver.domain.user.entity.UserEntity;
+import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 
+@Getter
 @Entity
 @Table(name="tool_scrap")
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ToolScrap {
+public class ToolScrap extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long toolScrapId;
@@ -25,4 +25,11 @@ public class ToolScrap {
     @JoinColumn(name="tool_id",nullable = false)
     private Tool tool;
 
+    @NotNull
+    @Builder.Default
+    private boolean delYn = false;
+
+    public void update() {
+        this.delYn = !this.delYn;
+    }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolScrapRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolScrapRepository.java
@@ -3,18 +3,15 @@ package com.daruda.darudaserver.domain.tool.repository;
 import com.daruda.darudaserver.domain.tool.entity.Tool;
 import com.daruda.darudaserver.domain.tool.entity.ToolScrap;
 import com.daruda.darudaserver.domain.user.entity.UserEntity;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ToolScrapRepository extends JpaRepository<ToolScrap,Long> {
 
-
-
-    boolean existsByUserAndTool(final UserEntity user, final Tool tool);
-
     void deleteByUserAndTool(final UserEntity user, final Tool tool);
+
+    Optional<ToolScrap>  findByUserAndTool(UserEntity user, Tool tool);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -101,19 +101,19 @@ public class ToolService {
     @Transactional
     public ToolScrapRes postToolScrap(final Long userId, final Long toolId){
         UserEntity user = getUserById(userId);
-        Tool tool = getToolById(toolId); // Tool 검증
-        boolean toolExists = toolScrapRepository.existsByUserAndTool( user, tool);
-        if(toolExists){
-            toolScrapRepository.deleteByUserAndTool(user, tool);
-            return ToolScrapRes.of(toolId, false);
-        }else{
-            ToolScrap toolScrap = ToolScrap.builder()
+        Tool tool = getToolById(toolId);
+        ToolScrap toolScrap = toolScrapRepository.findByUserAndTool(user, tool).orElse(null);
+
+        if(toolScrap==null){
+            toolScrap = ToolScrap.builder()
                     .user(user)
                     .tool(tool)
                     .build();
             toolScrapRepository.save(toolScrap);
-            return ToolScrapRes.of(toolId, true);
+        }else{
+            toolScrap.update();
         }
+        return ToolScrapRes.of(toolId, !toolScrap.isDelYn());
     }
 
     private List<RelatedTool> relatedTool(final Tool tool) {

--- a/src/main/java/com/daruda/darudaserver/global/common/response/ScrollPaginationCollection.java
+++ b/src/main/java/com/daruda/darudaserver/global/common/response/ScrollPaginationCollection.java
@@ -15,10 +15,12 @@ public class ScrollPaginationCollection<T> {
                                                         int size){
         return new ScrollPaginationCollection<>(itemsWithNextCursor,size);
     }
+
     // 마지막 스크롤린지 확인하기 위한 메서드, 조회한 결과(countPerScroll) 이하로 조회시 마지막 스크롤 이라고 판단
     public boolean isLastScroll(){
         return this.itemsWithNextCursor.size() <= countPerScroll;
     }
+
     // 마지막 스크롤 일 경우 itemsWithNextCursor를 Return
     public List<T> getCurrentScrollItems(){
         // 마지막 스크롤일 경우
@@ -32,5 +34,9 @@ public class ScrollPaginationCollection<T> {
     // 마지막 데이터를 cursor 로 사용하고 Return
     public T getNextCursor(){
         return itemsWithNextCursor.get(countPerScroll - 1);
+    }
+
+    public long getTotalElements(){
+        return this.itemsWithNextCursor.size();
     }
 }

--- a/src/main/java/com/daruda/darudaserver/global/common/response/ScrollPaginationCollection.java
+++ b/src/main/java/com/daruda/darudaserver/global/common/response/ScrollPaginationCollection.java
@@ -1,0 +1,36 @@
+package com.daruda.darudaserver.global.common.response;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ScrollPaginationCollection<T> {
+
+    private final List <T> itemsWithNextCursor; // 현재 스크롤의 데이터 + 다음 스크롤의 데이터 1개(다음 데이터 확인 위함)
+    private final int countPerScroll; // 스크롤 1회에 조회할 데이터의 개수
+
+    public static <T> ScrollPaginationCollection <T> of (List<T> itemsWithNextCursor,
+                                                        int size){
+        return new ScrollPaginationCollection<>(itemsWithNextCursor,size);
+    }
+    // 마지막 스크롤린지 확인하기 위한 메서드, 조회한 결과(countPerScroll) 이하로 조회시 마지막 스크롤 이라고 판단
+    public boolean isLastScroll(){
+        return this.itemsWithNextCursor.size() <= countPerScroll;
+    }
+    // 마지막 스크롤 일 경우 itemsWithNextCursor를 Return
+    public List<T> getCurrentScrollItems(){
+        // 마지막 스크롤일 경우
+        if(isLastScroll()){
+            return this.itemsWithNextCursor;
+        }
+        // 마지막 스크롤이 아닐 경우 데이터 1개를 제외하고 Return
+        return this.itemsWithNextCursor.subList(0, countPerScroll);
+    }
+
+    // 마지막 데이터를 cursor 로 사용하고 Return
+    public T getNextCursor(){
+        return itemsWithNextCursor.get(countPerScroll - 1);
+    }
+}

--- a/src/main/java/com/daruda/darudaserver/global/error/code/SuccessCode.java
+++ b/src/main/java/com/daruda/darudaserver/global/error/code/SuccessCode.java
@@ -12,7 +12,7 @@ public enum SuccessCode {
     SUCCESS_UPDATE(HttpStatus.OK, "업데이트가 완료되었습니다"),
     SUCCESS_DELETE(HttpStatus.OK, "삭제가 완료되었습니다"),
     SUCCESS_FETCH(HttpStatus.OK, "요청 데이터가 성공적으로 조회되었습니다"),
-    SUCCESS_SCRAP(HttpStatus.OK,  "스크랩이 완료되었습니다");
+    SUCCESS_SCRAP(HttpStatus.OK,  "스크랩이 변경이 완료되었습니다");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #47 

## 📝 Summary
- 게시글 리스트 조회 
- 무한 스크롤 DTO 생성
- 스크랩 테이블 수정 - isDelYn 으로 수정
- Scrap Entity 는 BaseTimeEntity 상속
참고 : https://velog.io/@orijoon98/Spring-%EB%AC%B4%ED%95%9C%EC%8A%A4%ED%81%AC%EB%A1%A4-%EA%B5%AC%ED%98%84-1-%EC%BB%A4%EC%84%9C-%EA%B8%B0%EB%B0%98-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%84%A4%EC%9D%B4%EC%85%98

## 🙏 Question & PR point
- toolId 가 -1 일 때 '자유' 로 조회하고, null 일 때 전체조회
-   "nextCursor": -1 이면 마지막 페이지(스크롤 이라는 뜻)
- lastBoardId 가 나오면 그거부터 size 개수대로 조회
- 전체적인 코드 분리랑  로그 추가했어요
- nextCurosr : 마지막 boardId. 그래서 param으로 lastBoardId 3 으로 입력하면 3보다 작은 것부터 다음 스크롤(페이지) 에 나오는 구조

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->

<img width="1054" alt="Screenshot 2025-01-15 at 10 10 21 PM" src="https://github.com/user-attachments/assets/06f6cb08-bb27-4bc4-8134-cafdc1347d7e" />
