### PR TITLE
Fix/#97

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -55,9 +56,9 @@ public class BoardController {
      */
     @GetMapping("/boards/board/{board-id}")
     public ResponseEntity<ApiResponse<?>> getBoard(
-            @RequestHeader(value = "Access-Token" , required = false)String accessToken,
+            @AuthenticationPrincipal Long userIdOrNull,
             @PathVariable(name="board-id") final Long boardId){
-        BoardRes boardRes = boardService.getBoard(accessToken, boardId);
+        BoardRes boardRes = boardService.getBoard(userIdOrNull, boardId);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(boardRes,SuccessCode.SUCCESS_FETCH));
     }
 
@@ -88,13 +89,13 @@ public class BoardController {
      */
     @GetMapping("boards/board/list")
     public ResponseEntity <ApiResponse<?>> getBoardList(
-            @RequestHeader(value = "Access-Token" , required = false)String accessToken,
+            @AuthenticationPrincipal Long userIdOrNull,
             @RequestParam(name="isFree") Boolean isFree,
             @RequestParam(name = "toolId",required = false) Long toolId,
             @RequestParam(value = "size", defaultValue = "10") int size,
             @RequestParam(value = "lastBoardId", required = false) Long lastBoardId )
     {
-        GetBoardResponse boardResponse =  boardService.getBoardList(accessToken, isFree, toolId, size, lastBoardId);
+        GetBoardResponse boardResponse =  boardService.getBoardList(userIdOrNull, isFree, toolId, size, lastBoardId);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(boardResponse, SuccessCode.SUCCESS_FETCH));
     }
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -125,8 +125,8 @@ public class BoardService {
     }
 
     // 게시판 조회
-    public BoardRes getBoard(final String accessToken, final Long boardId) {
-        UserEntity user = getUser(accessToken);
+    public BoardRes getBoard(final Long userIdOrNull, final Long boardId) {
+        UserEntity user = getUser(userIdOrNull);
         Board board = getBoardById(boardId);
         List<String> imageUrls = boardImageService.getBoardImageUrls(boardId);
         String toolName = board.getTool() != null ? board.getTool().getToolMainName() : FREE;
@@ -145,13 +145,13 @@ public class BoardService {
     }
 
     // 게시판 리스트 조회
-    public GetBoardResponse getBoardList(final String accessToken, final Boolean isFree,final Long toolId, final int size, final Long lastBoardId) {
+    public GetBoardResponse getBoardList(final Long userIdOrNull, final Boolean isFree,final Long toolId, final int size, final Long lastBoardId) {
 
         List<Board> boards;
         Long cursor = (lastBoardId == null) ? Long.MAX_VALUE : lastBoardId;
         PageRequest pageRequest = PageRequest.of(0, size + 1);
 
-        UserEntity user = getUser(accessToken);
+        UserEntity user = getUser(userIdOrNull);
         // 전체 조회
         if(Boolean.TRUE.equals(isFree)){
             log.info("자유 게시판을 조회합니다");
@@ -266,10 +266,10 @@ public class BoardService {
     }
 
 
-    public UserEntity getUser(String accessToken) {
+    public UserEntity getUser(Long userIdOrNull) {
         UserEntity user = null;
-        if (accessToken != null) {
-            Long userId = jwtTokenProvider.getUserIdFromJwt(accessToken);
+        if (userIdOrNull != null) {
+            Long userId = userIdOrNull;
             user = userRepository.findById(userId)
                     .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
             log.debug("유저 정보를 조회했습니다: {}", user.getId());

--- a/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
@@ -10,6 +10,7 @@ import com.daruda.darudaserver.global.error.code.SuccessCode;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Arrays;
@@ -28,8 +29,8 @@ public class ToolController {
      * 툴 세부정보 조회
      */
     @GetMapping("/tools/{tool-id}")
-    public ResponseEntity<ApiResponse<?>> getToolDetail(  @RequestHeader(value = "Access-Token" , required = false)String accessToken,@PathVariable(name="tool-id") final Long toolId){
-        ToolDetailGetRes toolDetail = toolService.getToolDetail(accessToken, toolId);
+    public ResponseEntity<ApiResponse<?>> getToolDetail(@AuthenticationPrincipal Long userIdOrNull,@PathVariable(name="tool-id") final Long toolId){
+        ToolDetailGetRes toolDetail = toolService.getToolDetail(userIdOrNull, toolId);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(toolDetail, SuccessCode.SUCCESS_FETCH));
     }
 
@@ -65,7 +66,7 @@ public class ToolController {
      */
     @GetMapping("/tools")
     public ResponseEntity<ApiResponse<?>> getToolList(
-            @RequestHeader(value = "Access-Token" , required = false)String accessToken,
+            @AuthenticationPrincipal Long userIdOrNull,
             @RequestParam(defaultValue = "popular", value="criteria") String criteria,
             @RequestParam(defaultValue = "ALL",value="category") String category,
             @RequestParam(value = "size", defaultValue = "18") int size,
@@ -73,7 +74,7 @@ public class ToolController {
                                                              ){
         Category categoryEnum = Category.fromEnglishName(category);
         ToolListRes toolListRes = toolService.
-                getToolList(accessToken , criteria , categoryEnum, size, lastToolId);
+                getToolList(userIdOrNull, criteria , categoryEnum, size, lastToolId);
         return ResponseEntity.ok(ApiResponse.ofSuccessWithData(toolListRes,SuccessCode.SUCCESS_FETCH));
     }
     /**

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -41,7 +41,7 @@ public class ToolService {
 
 
     public ToolDetailGetRes getToolDetail(final Long userIdOrNull, final Long toolId) {
-        log.info("툴 세부 정보를 조회합니다. toolId={}", userIdOrNull);
+        log.info("툴 세부 정보를 조회합니다. toolId={}" + userIdOrNull);
 
         Tool tool = getToolById(toolId);
         List<String> images = getImageById(tool);
@@ -63,7 +63,7 @@ public class ToolService {
         log.debug("툴의 조회수가 증가되었습니다" + tool.getViewCount());
         log.info("툴 세부 정보를 성공적으로 조회했습니다. toolId={}", toolId);
         toolRepository.save(tool);
-        return ToolDetailGetRes.of(tool, platformRes, keywordRes, images, videos,isScrapped);
+        return ToolDetailGetRes.of(tool, platformRes, keywordRes, images, videos, !isScrapped);
     }
 
     public PlanListRes getPlan(final Long toolId) {
@@ -143,7 +143,7 @@ public class ToolService {
                                     .map(toolScrap -> !toolScrap.isDelYn())
                                     .orElse(false));
                     System.out.println("isScraped = " + isScraped);
-                    return ToolResponse.of(tool, convertToKeywordRes(tool), isScraped);
+                    return ToolResponse.of(tool, convertToKeywordRes(tool), !isScraped);
                 })
                 .toList();
 
@@ -217,7 +217,7 @@ public class ToolService {
 
     private List<String> getVideoById(final Tool tool) {
         List<ToolVideo> toolVideos = toolVideoRepository.findAllByTool(tool);
-        validateList(toolVideos);
+        //validateList(toolVideos);
         log.debug("툴에 연결된 비디오 목록을 조회했습니다");
         return toolVideos.stream()
                 .map(ToolVideo::getVideoUrl)

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -40,8 +40,8 @@ public class ToolService {
     private final JwtTokenProvider jwtTokenProvider;
 
 
-    public ToolDetailGetRes getToolDetail(final String accessToken, final Long toolId) {
-        log.info("툴 세부 정보를 조회합니다. toolId={}", toolId);
+    public ToolDetailGetRes getToolDetail(final Long userIdOrNull, final Long toolId) {
+        log.info("툴 세부 정보를 조회합니다. toolId={}", userIdOrNull);
 
         Tool tool = getToolById(toolId);
         List<String> images = getImageById(tool);
@@ -53,8 +53,8 @@ public class ToolService {
         UserEntity user;
         Boolean isScrapped = false;
         //AccessToken 이 들어왔을 경우
-        if (accessToken != null) {
-            Long userId = jwtTokenProvider.getUserIdFromJwt(accessToken);
+        if (userIdOrNull != null) {
+            Long userId = userIdOrNull;
             user = userRepository.findById(userId)
                     .orElse(null);
             log.debug("유저 정보를 조회했습니다: {}", user.getId());
@@ -99,12 +99,12 @@ public class ToolService {
         return RelatedToolListRes.of(relatedToolResList);
     }
 
-    public ToolListRes getToolList(final String accessToken, final String criteria, final Category category, final int size, final Long lastToolId) {
+    public ToolListRes getToolList(final Long userIdOrNull, final String criteria, final Category category, final int size, final Long lastToolId) {
         log.debug("카테고리별 툴 목록을 조회 category: {}, sort: {}, size: {}, lastToolId: {}", category, criteria, size, lastToolId);
 
         UserEntity user;
-        if (accessToken != null) {
-            Long userId = jwtTokenProvider.getUserIdFromJwt(accessToken);
+        if (userIdOrNull != null) {
+            Long userId = userIdOrNull;
             user = userRepository.findById(userId)
                     .orElseThrow(() -> new NotFoundException(ErrorCode.SCRAP_NOT_FOUND));
             log.debug("유저 정보를 조회했습니다: {}", user.getId());

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
@@ -33,9 +33,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final List<String> EXCLUDE_URL = Arrays.asList("/api/v1/users/signin",
             "/api/v1/users/token",
             "/api/v1/users/signup",
-            "/api/v1/users/nickname",
+            "/api/v1/users/nickname");
             //"/api/v1/boards/board/**",
-            "/api/v1/tools/**");
+           // "/api/v1/tools/**"
 
     @Override
     protected void doFilterInternal( HttpServletRequest request,  HttpServletResponse response,  FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
@@ -34,7 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/v1/users/token",
             "/api/v1/users/signup",
             "/api/v1/users/nickname",
-            "/api/v1/boards/board/**",
+            //"/api/v1/boards/board/**",
             "/api/v1/tools/**");
 
     @Override


### PR DESCRIPTION
## 📣 Related Issue
- close #97 

## 📝 Summary

1. accessToken이 null일 때 scrap여부는 전부 false로 나갑니다(툴 상세,리스트 조회 / 게시글(리스트) 조회
3. 기존에는 ToolDetail을 조회할 때 관련 영상이 없으면 Exception을 던지도록 되어있었던 것을 null을 반환하도록 변경하였습니다
4. JwtAuthenticFilter에서 tool과 board와 관련된 부분을 WHITE_LIST에서 제외했습니다
