### PR TITLE
#185 [fix] 리프레시 토큰 업데이트 로직 수정

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
@@ -1,7 +1,6 @@
 package com.daruda.darudaserver.domain.user.service;
 import com.daruda.darudaserver.domain.comment.repository.CommentRepository;
 import com.daruda.darudaserver.domain.community.entity.Board;
-import com.daruda.darudaserver.domain.community.entity.BoardScrap;
 import com.daruda.darudaserver.domain.community.repository.BoardRepository;
 import com.daruda.darudaserver.domain.community.repository.BoardScrapRepository;
 import com.daruda.darudaserver.domain.tool.dto.res.ToolDtoGetRes;
@@ -26,10 +25,6 @@ import com.daruda.darudaserver.global.error.exception.NotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -49,7 +44,6 @@ public class UserService {
     private final ToolService toolService;
     private final BoardRepository boardRepository;
     private final CommentRepository commentRepository;
-    private final TokenRepository tokenRepository;
 
     public LoginResponse oAuthLogin(final UserInfo userInfo) {
         String email = userInfo.email();
@@ -59,7 +53,7 @@ public class UserService {
             return LoginResponse.of(false, email,null);
         } else { //등록된 회원인 경우
             Long userId = userEntity.get().getId();
-            log.debug("유저 아이디를 성공적으로 조회했습니다. userId : ,{}", userId);
+            log.debug("유저 아이디를 성공적으로 조회했습니다. userId : {}", userId);
             UserAuthentication userAuthentication = UserAuthentication.createUserAuthentication(userId);
 
             //토큰 생성 및 refreshToken db에 저장

--- a/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
@@ -52,14 +52,10 @@ public class TokenService {
     }
 
     public String updateRefreshTokenByUserId(Long userId){
-        Token token = tokenRepository.findByUserId(userId)
-                .orElseThrow(()->new NotFoundException(ErrorCode.USER_NOT_FOUND));
+        tokenRepository.findByUserId(userId).ifPresent(tokenRepository::delete);
 
-        tokenRepository.delete(token);
         UserAuthentication userAuthentication = UserAuthentication.createUserAuthentication(userId);
-        String refreshToken = jwtTokenProvider.generateRefreshToken(userAuthentication);
-
-        return refreshToken;
+        return  jwtTokenProvider.generateRefreshToken(userAuthentication);
     }
 
 }


### PR DESCRIPTION
## 📣 Related Issue
- close #185 

## 📝 Summary
기존에는 DB에 리프레쉬 토큰이 없다면 404 Not Found를 던져주었지만 수정 후에는 null이 아닐 경우 삭제 후 재발급 하고 null일 경우에는 재발급만 해주는 로직으로 변경