### PR TITLE
#213 [fix] 중복데이터 있어도 첫 번째 데이터 반환하도록 변경

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -193,7 +193,7 @@ public class BoardService {
                         noTopic != null ? board.isFree.eq(noTopic) : null,
                         toolId != null ? board.tool.toolId.eq(toolId) : null
                 )
-                .fetchOne()).orElse(0L);
+                .fetchFirst()).orElse(0L);
 
         // Cursor 기반 페이징을 적용한 게시글 목록 가져오기
         List<Board> boards = jpaQueryFactory


### PR DESCRIPTION
## 📣 Related Issue
- close #213 

## 📝 Summary
fetchOne() -> fetchFirst()로 변경하여 중복데이터를 반환하더라도 첫 번째 결과만 반환하도록 변경


## 🙏 Question & PR point

