### PR TITLE
#278 [fix] 임시 이미지 조회 안 됨 해결

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardImageService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardImageService.java
@@ -30,7 +30,7 @@ public class BoardImageService {
 
 	public List<String> getBoardImageUrls(Long boardId) {
 		return boardImageRepository.findAllByBoardId(boardId).stream()
-			.map(boardImage -> imageService.getImageUrlById(boardImage.getImageId()))
+			.map(boardImage -> IMAGE_URL + imageService.getImageUrlById(boardImage.getImageId()))
 			.toList();
 	}
 


### PR DESCRIPTION
## 📣 Related Issue

- close #278 

## 📝 Summary

- 이미지 업로드 및 저장 로직을 변경하면서  기존에는 "https://d10hjhy1a1c8eq.cloudfront.net/" 를 직접 붙여서 응답을 내려준 반면 변경된 로직은 애초에 앞에 url을 붙여서 클라 쪽에서 요청을 보내고 이를 저장합니다. 따라서 조회 메서드에서 "https://d10hjhy1a1c8eq.cloudfront.net/" 를 뺴고 응답을 내려주는 바람에 이미지들이 조회되지 않는 문제가 발생하였습니다.
따라서 임시로 "https://d10hjhy1a1c8eq.cloudfront.net/"를 다시 붙여주어 일단은 조회가 되게끔 변경하였습니다

## 🙏 Question & PR point

- db에 있는 이미지들을 어떻게 처리해줘야할지 모르겠네요.. 이걸 전부 다 날릴 순 없고 그렇다고 "https://d10hjhy1a1c8eq.cloudfront.net/"를 일일이 다 붙여주기엔 데이터 양이 너무 많고..

## 📬 Postman

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/5992b68f-db66-4ed0-8a88-d5fca47d878b" />

### 현재 DB에 저장되어있는 정보
<img width="552" alt="image" src="https://github.com/user-attachments/assets/0d8ed2f4-4e1a-43a1-ae05-722ba07ce3d5" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
    - 게시글 이미지의 URL이 항상 올바른 기본 경로로 시작하도록 개선되었습니다. 이제 이미지가 정상적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->