### PR TITLE
#348 [Refactor] 알림 기능 개선

### DIFF
--- a/src/main/java/com/daruda/darudaserver/DarudaApplication.java
+++ b/src/main/java/com/daruda/darudaserver/DarudaApplication.java
@@ -6,13 +6,11 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration;
 
 @EnableJpaAuditing
 @EnableFeignClients
-@EnableWebMvc
 @EnableAsync
 @EnableRetry
 @SpringBootApplication(exclude = {S3AutoConfiguration.class})

--- a/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
@@ -40,6 +40,8 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
 	@Query("SELECT COUNT(c) FROM CommentEntity c WHERE c.board.id = :boardId AND c.isDeleted = false")
 	int countByBoardId(@Param("boardId") Long boardId);
 
-	@Query("SELECT DISTINCT c.user FROM CommentEntity c WHERE c.board.id = :boardId")
+	@Query("SELECT DISTINCT c.user FROM CommentEntity c "
+		+ "WHERE c.board.id = :boardId "
+		+ "AND c.isDeleted = false ")
 	List<UserEntity> findDistinctUserByBoardId(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.daruda.darudaserver.domain.comment.entity.CommentEntity;
+import com.daruda.darudaserver.domain.user.entity.UserEntity;
 
 import jakarta.transaction.Transactional;
 
@@ -38,4 +39,7 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
 
 	@Query("SELECT COUNT(c) FROM CommentEntity c WHERE c.board.id = :boardId AND c.isDeleted = false")
 	int countByBoardId(@Param("boardId") Long boardId);
+
+	@Query("SELECT DISTINCT c.user FROM CommentEntity c WHERE c.board.id = :boardId")
+	List<UserEntity> findDistinctUserByBoardId(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/notification/dto/request/NoticeRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/dto/request/NoticeRequest.java
@@ -8,8 +8,7 @@ public record NoticeRequest(
 	@Size(max = 100, message = "제목은 100자 이내로 입력해주세요")
 	String title,
 
-	@NotBlank(message = "내용은 필수 입력값입니다")
-	@Size(max = 1000, message = "내용은 1000자 이내로 입력해주세요")
-	String content
+	@NotBlank(message = "URL은 필수 입력값입니다")
+	String url
 ) {
 }

--- a/src/main/java/com/daruda/darudaserver/domain/notification/dto/request/NoticeRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/dto/request/NoticeRequest.java
@@ -1,6 +1,7 @@
 package com.daruda.darudaserver.domain.notification.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record NoticeRequest(
@@ -9,6 +10,7 @@ public record NoticeRequest(
 	String title,
 
 	@NotBlank(message = "URL은 필수 입력값입니다")
+	@Pattern(regexp = "^(http|https)://.*$", message = "올바른 URL 형식이 아닙니다")
 	String url
 ) {
 }

--- a/src/main/java/com/daruda/darudaserver/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/dto/response/NotificationResponse.java
@@ -15,7 +15,8 @@ public record NotificationResponse(
 	NotificationType type,
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
 	Timestamp createdAt,
-	boolean isRead
+	boolean isRead,
+	String url
 ) {
 	public static NotificationResponse from(NotificationEntity notificationEntity) {
 		return new NotificationResponse(
@@ -25,7 +26,8 @@ public record NotificationResponse(
 			getBoardId(notificationEntity.getComment()),
 			notificationEntity.getType(),
 			notificationEntity.getCreatedAt(),
-			notificationEntity.isRead()
+			notificationEntity.isRead(),
+			notificationEntity.getUrl()
 		);
 	}
 

--- a/src/main/java/com/daruda/darudaserver/domain/notification/entity/NotificationEntity.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/entity/NotificationEntity.java
@@ -53,15 +53,19 @@ public class NotificationEntity extends BaseTimeEntity {
 	@Column(nullable = false)
 	private boolean isRead;
 
+	@Column
+	private String url;
+
 	@Builder
-	private NotificationEntity(String title, String content, CommentEntity comment, UserEntity receiver,
-		NotificationType type, boolean isRead) {
+	public NotificationEntity(String title, String content, CommentEntity comment, UserEntity receiver,
+		NotificationType type, boolean isRead, String url) {
 		this.title = title;
 		this.content = content;
 		this.comment = comment;
 		this.receiver = receiver;
 		this.type = type;
 		this.isRead = isRead;
+		this.url = url;
 	}
 
 	public static NotificationEntity of(UserEntity receiver, NotificationType type, String title, String content,

--- a/src/main/java/com/daruda/darudaserver/domain/notification/entity/enums/NotificationFormat.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/entity/enums/NotificationFormat.java
@@ -18,11 +18,12 @@ public enum NotificationFormat {
 
 	// 서비스 제한 알림 형식
 	COMMUNITY_BLOCK_NOTICE_TITLE("[공지] %s님의 신고가 접수되었습니다."),
-	COMMUNITY_BLOCK_NOTICE_CONTENT("회원님께서는 \n"
-		+ "커뮤니티이용규칙을 위반하여\n"
-		+ "%s부로 %d일간 커뮤니티의 일부 활동을 제한합니다. \n"
-		+ "문의사항이 있다면 홈 화면 우측 상단의 ‘문의하기’를 이용해 주시기 바랍니다.\n"
-		+ "감사합니다.");
+	COMMUNITY_BLOCK_NOTICE_CONTENT("""
+		회원님께서는\s
+		커뮤니티이용규칙을 위반하여
+		%s부로 %d일간 커뮤니티의 일부 활동을 제한합니다.\s
+		문의사항이 있다면 홈 화면 우측 상단의 ‘문의하기’를 이용해 주시기 바랍니다.
+		감사합니다.""");
 
 	private final String messageFormat;
 

--- a/src/main/java/com/daruda/darudaserver/domain/notification/entity/enums/NotificationFormat.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/entity/enums/NotificationFormat.java
@@ -6,23 +6,27 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationFormat {
-	COMMENT_NOTIFICATION_TITLE("내가 쓴 글에 댓글이 달렸어요: %s"),
-	COMMUNITY_BLOCK_NOTICE_TITLE("[공지] %s님의 신고가 접수되었습니다."),
-	REGISTER_NOTICE_TITLE("[공지] daruda에 오신 걸 환영합니다!"),
+	// 댓글 알림 형식
+	COMMENT_TITLE_TEXT_ONLY("%s"),
+	COMMENT_TITLE_IMAGE_ONLY("[이미지]"),
+	COMMENT_TITLE_IMAGE_WITH_TEXT("[이미지] %s"),
+	COMMENT_CONTENT_BOARD_TITLE("%s"),
 
-	COMMENT_NOTIFICATION_CONTENT("제목: %s"),
+	// 공지사항 형식
+	NOTICE_TITLE("[공지] %s"),
+	NOTICE_CONTENT("팀 Faber"),
+
+	// 서비스 제한 알림 형식
+	COMMUNITY_BLOCK_NOTICE_TITLE("[공지] %s님의 신고가 접수되었습니다."),
 	COMMUNITY_BLOCK_NOTICE_CONTENT("회원님께서는 \n"
 		+ "커뮤니티이용규칙을 위반하여\n"
 		+ "%s부로 %d일간 커뮤니티의 일부 활동을 제한합니다. \n"
 		+ "문의사항이 있다면 홈 화면 우측 상단의 ‘문의하기’를 이용해 주시기 바랍니다.\n"
-		+ "감사합니다."),
-	REGISTER_NOTICE_CONTENT("안녕하세요,\n"
-		+ "대학생활에 필요한 툴을 다루다, daruda입니다.\n"
-		+ "daruda에서는 다양한 툴의 플랜, 기능, 특징 등을 한눈에 확인할 수 있어요.\n"
-		+ "지금 회원님께 가장 잘 맞는 툴을 찾아보세요!\n"
-		+ "툴에 대해 궁금한 점이 있다면, 커뮤니티에서 다른 유저들과 자유롭게 소통하며 정보를 나눌 수 있어요.\n"
-		+ "회원님의 방문을 진심으로 환영합니다.\n"
 		+ "감사합니다.");
 
 	private final String messageFormat;
+
+	public String format(Object... args) {
+		return String.format(messageFormat, args);
+	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/service/NotificationService.java
@@ -12,6 +12,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.daruda.darudaserver.domain.comment.entity.CommentEntity;
@@ -213,13 +215,20 @@ public class NotificationService {
 
 		notificationRepository.save(notificationEntity);
 
-		String userId = String.valueOf(receiver.getId());
-		Map<String, SseEmitter> sseEmitters = emitterRepository.findAllEmitterStartWithByUserId(userId);
-		sseEmitters.forEach(
-			(key, emitter) -> {
-				emitterRepository.saveEventCache(key, notificationEntity);
-				if (isSendFailedToClient(emitter, key, NotificationResponse.from(notificationEntity))) {
-					log.warn("알림 전송 실패 - emitterId: {}, 수신자: {}", key, receiver.getEmail());
+		TransactionSynchronizationManager.registerSynchronization(
+			new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					String userId = String.valueOf(receiver.getId());
+					Map<String, SseEmitter> sseEmitters = emitterRepository.findAllEmitterStartWithByUserId(userId);
+					sseEmitters.forEach(
+						(key, emitter) -> {
+							emitterRepository.saveEventCache(key, notificationEntity);
+							if (isSendFailedToClient(emitter, key, NotificationResponse.from(notificationEntity))) {
+								log.warn("알림 전송 실패 - emitterId: {}, 수신자: {}", key, receiver.getEmail());
+							}
+						}
+					);
 				}
 			}
 		);

--- a/src/main/java/com/daruda/darudaserver/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/service/NotificationService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.daruda.darudaserver.domain.comment.entity.CommentEntity;
+import com.daruda.darudaserver.domain.comment.repository.CommentRepository;
 import com.daruda.darudaserver.domain.community.entity.Board;
 import com.daruda.darudaserver.domain.notification.dto.request.CommunityBlockNoticeRequest;
 import com.daruda.darudaserver.domain.notification.dto.request.NoticeRequest;
@@ -45,6 +46,7 @@ public class NotificationService {
 	private final UserRepository userRepository;
 	private final EmitterRepository emitterRepository;
 	private final NotificationRepository notificationRepository;
+	private final CommentRepository commentRepository;
 
 	public SseEmitter subscribe(Long userId, String lastEventId) {
 		String emitterId = userId + "_" + System.currentTimeMillis();
@@ -84,11 +86,37 @@ public class NotificationService {
 	@Transactional
 	public void sendCommentNotification(CommentEntity commentEntity) {
 		Board board = commentEntity.getBoard();
+		UserEntity commenter = commentEntity.getUser();
 
-		String title = String.format(COMMENT_NOTIFICATION_TITLE.getMessageFormat(), commentEntity.getContent());
-		String content = String.format(COMMENT_NOTIFICATION_CONTENT.getMessageFormat(), board.getTitle());
+		String title = createCommentNotificationTitle(commentEntity);
+		String content = COMMENT_CONTENT_BOARD_TITLE.format(board.getTitle());
 
-		send(board.getUser(), NotificationType.COMMENT, title, content, commentEntity);
+		// 1. 게시글 작성자에게 알림 (내가 쓴 글에 내가 댓글 다는 것 제외)
+		if (!board.getUser().getId().equals(commenter.getId())) {
+			send(board.getUser(), NotificationType.COMMENT, title, content, commentEntity, null);
+		}
+
+		// 2. 다른 댓글 작성자들에게 알림
+		List<UserEntity> otherCommenters = commentRepository.findDistinctUserByBoardId(board.getId());
+		for (UserEntity receiver : otherCommenters) {
+			// 알림 받을 사람이 댓글 작성자 본인이 아니고, 게시글 작성자도 아닐 경우 (게시글 작성자는 위에서 보냄)
+			if (!receiver.getId().equals(commenter.getId()) && !receiver.getId().equals(board.getUser().getId())) {
+				send(receiver, NotificationType.COMMENT, title, content, commentEntity, null);
+			}
+		}
+	}
+
+	private String createCommentNotificationTitle(CommentEntity commentEntity) {
+		boolean hasPhoto = commentEntity.getPhotoUrl() != null && !commentEntity.getPhotoUrl().isEmpty();
+		boolean hasText = commentEntity.getContent() != null && !commentEntity.getContent().isEmpty();
+
+		if (hasPhoto && hasText) {
+			return COMMENT_TITLE_IMAGE_WITH_TEXT.format(commentEntity.getContent());
+		}
+		if (hasPhoto) {
+			return COMMENT_TITLE_IMAGE_ONLY.getMessageFormat();
+		}
+		return COMMENT_TITLE_TEXT_ONLY.format(commentEntity.getContent());
 	}
 
 	@Transactional
@@ -103,9 +131,10 @@ public class NotificationService {
 			for (UserEntity userEntity : users.getContent()) {
 				send(userEntity,
 					NotificationType.NOTICE,
-					noticeRequest.title(),
-					noticeRequest.content(),
-					null);
+					NOTICE_TITLE.format(noticeRequest.title()),
+					NOTICE_CONTENT.getMessageFormat(),
+					null,
+					noticeRequest.url());
 			}
 			page++;
 		} while (users.hasNext());
@@ -122,16 +151,10 @@ public class NotificationService {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
 		String formattedDate = now.format(formatter);
 
-		String title = String.format(COMMUNITY_BLOCK_NOTICE_TITLE.getMessageFormat(), receiver.getNickname());
-		String content = String.format(COMMUNITY_BLOCK_NOTICE_CONTENT.getMessageFormat(), formattedDate,
-			blockDurationInDay.getDays());
+		String title = COMMUNITY_BLOCK_NOTICE_TITLE.format(receiver.getNickname());
+		String content = COMMUNITY_BLOCK_NOTICE_CONTENT.format(formattedDate, blockDurationInDay.getDays());
 
-		send(receiver, NotificationType.NOTICE, title, content, null);
-	}
-
-	public void sendRegisterNotice(UserEntity userEntity) {
-		send(userEntity, NotificationType.NOTICE, REGISTER_NOTICE_TITLE.getMessageFormat(),
-			REGISTER_NOTICE_CONTENT.getMessageFormat(), null);
+		send(receiver, NotificationType.NOTICE, title, content, null, null);
 	}
 
 	@Transactional
@@ -175,19 +198,26 @@ public class NotificationService {
 	}
 
 	private void send(UserEntity receiver, NotificationType notificationType, String title, String content,
-		CommentEntity commentEntity) {
-		NotificationEntity notificationEntity = NotificationEntity.of(receiver, notificationType, title, content,
-			commentEntity);
-		String userId = String.valueOf(receiver.getId());
+		CommentEntity commentEntity, String url) {
+		NotificationEntity notificationEntity = NotificationEntity.builder()
+			.receiver(receiver)
+			.type(notificationType)
+			.title(title)
+			.content(content)
+			.comment(commentEntity)
+			.url(url)
+			.isRead(false)
+			.build();
 
+		notificationRepository.save(notificationEntity);
+
+		String userId = String.valueOf(receiver.getId());
 		Map<String, SseEmitter> sseEmitters = emitterRepository.findAllEmitterStartWithByUserId(userId);
 		sseEmitters.forEach(
 			(key, emitter) -> {
 				emitterRepository.saveEventCache(key, notificationEntity);
 				if (isSendFailedToClient(emitter, key, NotificationResponse.from(notificationEntity))) {
 					log.warn("알림 전송 실패 - emitterId: {}, 수신자: {}", key, receiver.getEmail());
-				} else {
-					notificationRepository.save(notificationEntity);
 				}
 			}
 		);

--- a/src/main/java/com/daruda/darudaserver/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/service/NotificationService.java
@@ -107,16 +107,18 @@ public class NotificationService {
 	}
 
 	private String createCommentNotificationTitle(CommentEntity commentEntity) {
-		boolean hasPhoto = commentEntity.getPhotoUrl() != null && !commentEntity.getPhotoUrl().isEmpty();
-		boolean hasText = commentEntity.getContent() != null && !commentEntity.getContent().isEmpty();
+		boolean hasPhoto = commentEntity.getPhotoUrl() != null && !commentEntity.getPhotoUrl().isBlank();
+		boolean hasText = commentEntity.getContent() != null && !commentEntity.getContent().isBlank();
 
 		if (hasPhoto && hasText) {
-			return COMMENT_TITLE_IMAGE_WITH_TEXT.format(commentEntity.getContent());
+			return COMMENT_TITLE_IMAGE_WITH_TEXT.format(commentEntity.getContent().trim());
 		}
 		if (hasPhoto) {
 			return COMMENT_TITLE_IMAGE_ONLY.getMessageFormat();
 		}
-		return COMMENT_TITLE_TEXT_ONLY.format(commentEntity.getContent());
+		return hasText
+			? COMMENT_TITLE_TEXT_ONLY.format(commentEntity.getContent().trim())
+			: COMMENT_TITLE_TEXT_ONLY.format("(내용 없음)");
 	}
 
 	@Transactional

--- a/src/main/java/com/daruda/darudaserver/domain/user/service/AuthService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/AuthService.java
@@ -66,8 +66,6 @@ public class AuthService {
 
 		JwtTokenResponse jwtTokenResponse = tokenService.createToken(userId, role);
 
-		notificationService.sendRegisterNotice(userEntity);
-
 		return SignUpSuccessResponse.of(userEntity.getId(), nickname, positions, email, jwtTokenResponse);
 	}
 

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
@@ -40,7 +40,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		}
 
 		final String accessToken = getAccessToken(request);
-		log.debug("추출된 AccessToken: {}", accessToken);
 
 		if (StringUtils.hasText(accessToken)
 			&& jwtTokenProvider.validateToken(accessToken) == JwtValidationType.VALID_JWT) {

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
@@ -2,15 +2,12 @@ package com.daruda.darudaserver.global.auth.security;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.stereotype.Component;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -18,7 +15,6 @@ import com.daruda.darudaserver.global.auth.jwt.provider.JwtTokenProvider;
 import com.daruda.darudaserver.global.auth.jwt.provider.JwtValidationType;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.BadRequestException;
-import com.daruda.darudaserver.global.error.exception.UnauthorizedException;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -28,33 +24,21 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@Component
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
-	private static final List<String> EXCLUDE_URL = Arrays.asList(
-		"/swagger-ui/**",
-		"/v3/api-docs/**",
-		"/api/v1/user/nickname",
-		"/api/v1/comment",
-		"/api/v1/auth/sign-up",
-		"/api/v1/auth/login",
-		"/api/v1/auth/login-url",
-		"/api/v1/auth/reissue",
-		"/api/v1/tool/{tool-id}/plans",
-		"/api/v1/tool/{tool-id}/core-features",
-		"/api/v1/tool/{tool-id}/alternatives",
-		"/api/v1/tool/category",
-		"/api/v1/image/**"
-	);
 
 	private final JwtTokenProvider jwtTokenProvider;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
-		log.debug("JwtAuthenticationFilter 시작: 요청 URL - {}", request.getRequestURI());
+
+		if (request.getMethod().equals(HttpMethod.OPTIONS.name())) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
 		try {
 			final String accessToken = getAccessToken(request);
 			log.debug("추출된 AccessToken: {}", accessToken);
@@ -64,39 +48,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				Long userId = jwtTokenProvider.getUserIdFromJwt(accessToken);
 				String role = jwtTokenProvider.getRoleFromJwt(accessToken);
 				doAuthentication(request, userId, role);
-				log.info("JWT 인증 성공 - 사용자 ID: {} 역할: {}", userId, role);
 			}
 		} catch (Exception e) {
-			log.error("JWT 인증 실패: {}", e.getMessage(), e);
-			throw new UnauthorizedException(ErrorCode.EMPTY_OR_INVALID_TOKEN);
+			log.error("JWT 인증 에러: {}", e.getMessage());
 		}
+
 		filterChain.doFilter(request, response);
 	}
 
-	@Override
-	protected boolean shouldNotFilter(HttpServletRequest request) {
-
-		String path = request.getServletPath();
-		String method = request.getMethod();
-
-		if (method.equals(HttpMethod.GET.name())) {
-			return EXCLUDE_URL.stream().anyMatch(exclude -> new AntPathMatcher().match(exclude, path));
-		}
-		return false;
-	}
-
 	private String getAccessToken(HttpServletRequest request) {
-		try {
-			return
-				Arrays.stream(request.getCookies())
-					.filter(cookie -> "accessToken".equals(cookie.getName()))
-					.map(Cookie::getValue)
-					.findFirst()
-					.orElseThrow(() -> new UnauthorizedException(ErrorCode.EMPTY_OR_INVALID_TOKEN));
-		} catch (Exception e) {
-			log.warn("AccessToken 추출 실패: {}", e.getMessage());
+		if (request.getCookies() == null) {
 			return null;
 		}
+		return Arrays.stream(request.getCookies())
+			.filter(cookie -> "accessToken".equals(cookie.getName()))
+			.map(Cookie::getValue)
+			.findFirst()
+			.orElse(null);
 	}
 
 	private void doAuthentication(HttpServletRequest request, final Long userId, final String role) {

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
@@ -39,18 +39,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			return;
 		}
 
-		try {
-			final String accessToken = getAccessToken(request);
-			log.debug("추출된 AccessToken: {}", accessToken);
+		final String accessToken = getAccessToken(request);
+		log.debug("추출된 AccessToken: {}", accessToken);
 
-			if (StringUtils.hasText(accessToken)
-				&& jwtTokenProvider.validateToken(accessToken) == JwtValidationType.VALID_JWT) {
-				Long userId = jwtTokenProvider.getUserIdFromJwt(accessToken);
-				String role = jwtTokenProvider.getRoleFromJwt(accessToken);
-				doAuthentication(request, userId, role);
-			}
-		} catch (Exception e) {
-			log.error("JWT 인증 에러: {}", e.getMessage());
+		if (StringUtils.hasText(accessToken)
+			&& jwtTokenProvider.validateToken(accessToken) == JwtValidationType.VALID_JWT) {
+			Long userId = jwtTokenProvider.getUserIdFromJwt(accessToken);
+			String role = jwtTokenProvider.getRoleFromJwt(accessToken);
+			doAuthentication(request, userId, role);
 		}
 
 		filterChain.doFilter(request, response);

--- a/src/main/java/com/daruda/darudaserver/global/config/ElasticsearchIndexInitializer.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/ElasticsearchIndexInitializer.java
@@ -1,7 +1,7 @@
 package com.daruda.darudaserver.global.config;
 
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.stereotype.Component;
@@ -15,12 +15,12 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class ElasticsearchIndexInitializer {
+public class ElasticsearchIndexInitializer implements ApplicationRunner {
 
 	private final ElasticsearchOperations elasticsearchOperations;
 
-	@EventListener(ApplicationReadyEvent.class)
-	public void initializeIndices() {
+	@Override
+	public void run(ApplicationArguments args) {
 		log.info("Elasticsearch 인덱스 초기화 시작...");
 		initializeIndex(BoardDocument.class);
 		initializeIndex(ToolDocument.class);

--- a/src/main/java/com/daruda/darudaserver/global/config/ElasticsearchIndexInitializer.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/ElasticsearchIndexInitializer.java
@@ -1,0 +1,45 @@
+package com.daruda.darudaserver.global.config;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.stereotype.Component;
+
+import com.daruda.darudaserver.domain.search.document.BoardDocument;
+import com.daruda.darudaserver.domain.search.document.ToolDocument;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ElasticsearchIndexInitializer {
+
+	private final ElasticsearchOperations elasticsearchOperations;
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void initializeIndices() {
+		log.info("Elasticsearch 인덱스 초기화 시작...");
+		initializeIndex(BoardDocument.class);
+		initializeIndex(ToolDocument.class);
+		log.info("Elasticsearch 인덱스 초기화 완료.");
+	}
+
+	private void initializeIndex(Class<?> clazz) {
+		IndexOperations indexOps = elasticsearchOperations.indexOps(clazz);
+		if (!indexOps.exists()) {
+			log.info("{} 인덱스가 존재하지 않아 생성을 시도합니다.", clazz.getSimpleName());
+			try {
+				indexOps.create();
+				indexOps.putMapping(indexOps.createMapping());
+				log.info("{} 인덱스 생성 성공.", clazz.getSimpleName());
+			} catch (Exception e) {
+				log.error("{} 인덱스 생성 중 오류 발생: {}", clazz.getSimpleName(), e.getMessage());
+			}
+		} else {
+			log.info("{} 인덱스가 이미 존재합니다.", clazz.getSimpleName());
+		}
+	}
+}

--- a/src/main/java/com/daruda/darudaserver/global/config/ElasticsearchIndexInitializer.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/ElasticsearchIndexInitializer.java
@@ -28,18 +28,19 @@ public class ElasticsearchIndexInitializer {
 	}
 
 	private void initializeIndex(Class<?> clazz) {
-		IndexOperations indexOps = elasticsearchOperations.indexOps(clazz);
-		if (!indexOps.exists()) {
-			log.info("{} 인덱스가 존재하지 않아 생성을 시도합니다.", clazz.getSimpleName());
-			try {
+		try {
+			IndexOperations indexOps = elasticsearchOperations.indexOps(clazz);
+			if (!indexOps.exists()) {
+				log.info("{} 인덱스가 존재하지 않아 생성을 시도합니다.", clazz.getSimpleName());
 				indexOps.create();
 				indexOps.putMapping(indexOps.createMapping());
 				log.info("{} 인덱스 생성 성공.", clazz.getSimpleName());
-			} catch (Exception e) {
-				log.error("{} 인덱스 생성 중 오류 발생: {}", clazz.getSimpleName(), e.getMessage());
+			} else {
+				log.info("{} 인덱스가 이미 존재합니다.", clazz.getSimpleName());
 			}
-		} else {
-			log.info("{} 인덱스가 이미 존재합니다.", clazz.getSimpleName());
+		} catch (Exception e) {
+			log.error("{} 인덱스 초기화 실패", clazz.getSimpleName(), e);
+			throw new IllegalStateException(clazz.getSimpleName() + " 인덱스 초기화 실패", e);
 		}
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/global/config/ElasticsearchIndexInitializer.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/ElasticsearchIndexInitializer.java
@@ -32,7 +32,8 @@ public class ElasticsearchIndexInitializer {
 			IndexOperations indexOps = elasticsearchOperations.indexOps(clazz);
 			if (!indexOps.exists()) {
 				log.info("{} 인덱스가 존재하지 않아 생성을 시도합니다.", clazz.getSimpleName());
-				if (!indexOps.create()) {
+				boolean created = indexOps.create();
+				if (!created && !indexOps.exists()) {
 					throw new IllegalStateException(clazz.getSimpleName() + " 인덱스 생성 실패");
 				}
 

--- a/src/main/java/com/daruda/darudaserver/global/config/ElasticsearchIndexInitializer.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/ElasticsearchIndexInitializer.java
@@ -32,9 +32,15 @@ public class ElasticsearchIndexInitializer {
 			IndexOperations indexOps = elasticsearchOperations.indexOps(clazz);
 			if (!indexOps.exists()) {
 				log.info("{} 인덱스가 존재하지 않아 생성을 시도합니다.", clazz.getSimpleName());
-				indexOps.create();
-				indexOps.putMapping(indexOps.createMapping());
-				log.info("{} 인덱스 생성 성공.", clazz.getSimpleName());
+				if (!indexOps.create()) {
+					throw new IllegalStateException(clazz.getSimpleName() + " 인덱스 생성 실패");
+				}
+
+				if (!indexOps.putMapping(indexOps.createMapping())) {
+					throw new IllegalStateException(clazz.getSimpleName() + " 인덱스 매핑 적용 실패");
+				}
+
+				log.info("{} 인덱스 생성/매핑 성공.", clazz.getSimpleName());
 			} else {
 				log.info("{} 인덱스가 이미 존재합니다.", clazz.getSimpleName());
 			}

--- a/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
@@ -24,27 +24,42 @@ import lombok.RequiredArgsConstructor;
 @Configuration
 public class SecurityConfig {
 	private static final String[] WHITE_LIST = {
+		// Swagger & Docs
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
-		"/api/v1/user/nickname",
-		"/api/v1/comment",
-		"/api/v1/auth/sign-up",
-		"/api/v1/auth/login",
+		"/swagger-resources/**",
+		"/webjars/**",
+
+		// Auth
 		"/api/v1/auth/login-url",
+		"/api/v1/auth/login",
+		"/api/v1/auth/sign-up",
 		"/api/v1/auth/reissue",
-		"/api/v1/tool",
-		"/api/v1/tool/{tool-id}",
-		"/api/v1/tool/{tool-id}/plans",
-		"/api/v1/tool/{tool-id}/blogs",
-		"/api/v1/tool/{tool-id}/core-features",
-		"/api/v1/tool/{tool-id}/alternatives",
+
+		// Tool (Public 정보)
 		"/api/v1/tool/category",
-		"/api/v1/board",
-		"/api/v1/image/**",
-		"/api/v1/board/{board-id}",
-		"/api/v1/image/presigned-url",
+		"/api/v1/tool/{tool-id}/core-features",
+		"/api/v1/tool/{tool-id}/plans",
+		"/api/v1/tool/{tool-id}/alternatives",
+		"/api/v1/tool/{tool-id}/blogs",
+
+		// Search
 		"/api/v1/search/**",
-		"/error"
+
+		// User (Public 정보)
+		"/api/v1/user/nickname",
+		"/api/v1/user/boards",
+		"/api/v1/user/scrap-boards",
+
+		// Board & Comment (조회는 기본적으로 허용)
+		"/api/v1/board",
+		"/api/v1/board/{board-id}",
+		"/api/v1/comment",
+
+		// System
+		"/error",
+		"/favicon.ico",
+		"/"
 	};
 
 	private final CustomAccessDeniedHandler customAccessDeniedHandler;
@@ -65,21 +80,33 @@ public class SecurityConfig {
 				exceptionHandlingConfigurer
 					.authenticationEntryPoint(jwtAuthenticationEntryPoint)
 					.accessDeniedHandler(customAccessDeniedHandler))
-			.authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-				authorizationManagerRequestMatcherRegistry
-					.requestMatchers(HttpMethod.OPTIONS, "/**")
-					.permitAll() //OPTION 추가
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(HttpMethod.OPTIONS, "/**")
+				.permitAll()
 
-					.requestMatchers("/api/v1/admin/**")
-					.hasRole(Positions.ADMIN.getEngName())
+				// 관리자 API
+				.requestMatchers("/api/v1/admin/**")
+				.hasRole(Positions.ADMIN.getEngName())
 
-					.requestMatchers(HttpMethod.POST, "/api/v1/comment", "/api/v1/board", "/api/v1/board/{board-id}")
-					.authenticated()
+				// 인증이 필수인 상태 변경/개인화 API (POST, PATCH, DELETE 등)
+				.requestMatchers(HttpMethod.POST, "/api/v1/comment/**", "/api/v1/board/**", "/api/v1/notification/**",
+					"/api/v1/tool/*/scrap", "/api/v1/reports")
+				.authenticated()
+				.requestMatchers(HttpMethod.PATCH, "/api/v1/notification/**", "/api/v1/user/**", "/api/v1/board/**")
+				.authenticated()
+				.requestMatchers(HttpMethod.DELETE, "/api/v1/comment/**", "/api/v1/board/**", "/api/v1/auth/withdraw")
+				.authenticated()
+				.requestMatchers("/api/v1/auth/logout", "/api/v1/user/profile", "/api/v1/user/scrap-tools",
+					"/api/v1/notification/connect")
+				.authenticated()
 
-					.requestMatchers(WHITE_LIST)
-					.permitAll()
-					.anyRequest()
-					.authenticated())
+				// 나머지는 WHITE_LIST 허용
+				.requestMatchers(WHITE_LIST)
+				.permitAll()
+
+				// 그 외 정의되지 않은 모든 요청은 무시
+				.anyRequest()
+				.denyAll())
 			.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class);
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,7 +18,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,7 +18,7 @@ spring:
   jpa:
     show-sql: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,7 +18,7 @@ spring:
   jpa:
     show-sql: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/com/daruda/darudaserver/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/notification/controller/NotificationControllerTest.java
@@ -207,7 +207,7 @@ class NotificationControllerTest {
 		SecurityContext context = SecurityContextHolder.createEmptyContext();
 		context.setAuthentication(authentication);
 		SecurityContextHolder.setContext(context);
-		NoticeRequest request = new NoticeRequest("공지 제목", "공지 내용");
+		NoticeRequest request = new NoticeRequest("공지 제목", "https://notion.so/test");
 
 		// then
 		String token = "accessToken";

--- a/src/test/java/com/daruda/darudaserver/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/notification/service/NotificationServiceTest.java
@@ -1,6 +1,5 @@
 package com.daruda.darudaserver.domain.notification.service;
 
-import static com.daruda.darudaserver.domain.notification.entity.enums.NotificationFormat.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 

--- a/src/test/java/com/daruda/darudaserver/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/notification/service/NotificationServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.daruda.darudaserver.domain.comment.entity.CommentEntity;
+import com.daruda.darudaserver.domain.comment.repository.CommentRepository;
 import com.daruda.darudaserver.domain.community.entity.Board;
 import com.daruda.darudaserver.domain.notification.dto.request.CommunityBlockNoticeRequest;
 import com.daruda.darudaserver.domain.notification.dto.request.NoticeRequest;
@@ -53,6 +54,9 @@ class NotificationServiceTest {
 
 	@Mock
 	private NotificationRepository notificationRepository;
+
+	@Mock
+	private CommentRepository commentRepository;
 
 	@InjectMocks
 	private NotificationService notificationService;
@@ -139,53 +143,37 @@ class NotificationServiceTest {
 	@DisplayName("댓글 알림 전송 성공")
 	void sendCommentNotification_ShouldSendNotification() {
 		// given
-		Long userId = 1L;
-		String userIdString = "1";
-		String email = "test@example.com";
-		String nickname = "tester";
-		Positions positions = Positions.STUDENT;
-		UserEntity userEntity = UserEntity.of(email, nickname, positions);
-		ReflectionTestUtils.setField(userEntity, "id", userId); // id 설정
+		Long authorId = 1L;
+		Long commenterId = 2L;
+		Long otherCommenterId = 3L;
 
-		String toolName = "test";
-		Tool tool = Tool.builder().toolMainName(toolName).build();
+		UserEntity author = UserEntity.of("author@test.com", "author", Positions.STUDENT);
+		ReflectionTestUtils.setField(author, "id", authorId);
 
-		String communityTitle = "title";
-		String communityContent = "content";
-		Board board = Board.create(tool, userEntity, communityTitle, communityContent);
+		UserEntity commenter = UserEntity.of("commenter@test.com", "commenter", Positions.STUDENT);
+		ReflectionTestUtils.setField(commenter, "id", commenterId);
 
-		String photoUrl = "http://test.test";
-		CommentEntity comment = CommentEntity.of(communityContent, photoUrl, userEntity, board);
+		UserEntity otherCommenter = UserEntity.of("other@test.com", "other", Positions.STUDENT);
+		ReflectionTestUtils.setField(otherCommenter, "id", otherCommenterId);
 
-		String title = String.format(NotificationFormat.COMMENT_NOTIFICATION_TITLE.getMessageFormat(),
-			comment.getContent());
-		String content = String.format(NotificationFormat.COMMENT_NOTIFICATION_CONTENT.getMessageFormat(),
-			board.getTitle());
+		Tool tool = Tool.builder().toolMainName("test").build();
+		Board board = Board.create(tool, author, "board title", "board content");
+		ReflectionTestUtils.setField(board, "id", 100L);
 
-		NotificationEntity notification = NotificationEntity.of(userEntity, NotificationType.COMMENT, title, content,
-			comment);
-
-		SseEmitter emitter = mock(SseEmitter.class);
-		String emitterId = "1_12345";
+		CommentEntity comment = CommentEntity.of("new comment", null, commenter, board);
+		ReflectionTestUtils.setField(comment, "id", 200L);
 
 		// when
-		when(emitterRepository.findAllEmitterStartWithByUserId(userIdString)).thenReturn(Map.of(emitterId, emitter));
-		when(notificationRepository.save(any(NotificationEntity.class))).thenReturn(notification);
+		when(commentRepository.findDistinctUserByBoardId(100L)).thenReturn(List.of(author, commenter, otherCommenter));
+		when(emitterRepository.findAllEmitterStartWithByUserId(anyString())).thenReturn(Map.of());
 
 		notificationService.sendCommentNotification(comment);
 
 		// then
-		ArgumentCaptor<NotificationEntity> notificationCaptor = ArgumentCaptor.forClass(NotificationEntity.class);
-		verify(notificationRepository).save(notificationCaptor.capture());
-		NotificationEntity capturedNotification = notificationCaptor.getValue();
-
-		assertEquals(notification.getTitle(), capturedNotification.getTitle());
-		assertEquals(notification.getContent(), capturedNotification.getContent());
-		assertEquals(notification.getType(), capturedNotification.getType());
-
-		verify(emitterRepository).findAllEmitterStartWithByUserId(userIdString);
-		verify(emitterRepository).saveEventCache(eq(emitterId), any(NotificationEntity.class));
-		verifyNoMoreInteractions(emitterRepository);
+		// author should be notified, otherCommenter should be notified, commenter should NOT.
+		verify(emitterRepository).findAllEmitterStartWithByUserId(String.valueOf(authorId));
+		verify(emitterRepository).findAllEmitterStartWithByUserId(String.valueOf(otherCommenterId));
+		verify(emitterRepository, never()).findAllEmitterStartWithByUserId(String.valueOf(commenterId));
 	}
 
 	@Test
@@ -199,13 +187,13 @@ class NotificationServiceTest {
 		UserEntity user2 = UserEntity.of(email, nickname, positions);
 
 		String title = "title";
-		String content = "content";
+		String url = "https://notion.so/test";
 
 		// when
 		when(userRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(List.of(user1, user2)));
 		when(emitterRepository.findAllEmitterStartWithByUserId(anyString())).thenReturn(Map.of());
 
-		NoticeRequest noticeRequest = new NoticeRequest(title, content);
+		NoticeRequest noticeRequest = new NoticeRequest(title, url);
 		notificationService.sendNotice(noticeRequest);
 
 		// then
@@ -264,76 +252,6 @@ class NotificationServiceTest {
 
 		verify(emitterRepository).findAllEmitterStartWithByUserId(userIdString);
 		verify(emitterRepository).saveEventCache(eq(emitterId), any(NotificationEntity.class));
-		verifyNoMoreInteractions(emitterRepository);
-	}
-
-	@Test
-	@DisplayName("회원가입 알림 전송 성공")
-	void sendRegisterNotification_ShouldSendNotification() {
-		// given
-		Long userId = 1L;
-		String userIdString = "1";
-		String email = "test@example.com";
-		String nickname = "tester";
-		Positions positions = Positions.STUDENT;
-		UserEntity userEntity = UserEntity.of(email, nickname, positions);
-		ReflectionTestUtils.setField(userEntity, "id", userId); // id 설정
-
-		String title = REGISTER_NOTICE_TITLE.getMessageFormat();
-		String content = REGISTER_NOTICE_CONTENT.getMessageFormat();
-
-		NotificationEntity expectedNotification = NotificationEntity.of(userEntity, NotificationType.NOTICE, title,
-			content, null);
-
-		SseEmitter emitter = mock(SseEmitter.class);
-		String emitterId = "1_12345";
-
-		// when
-		when(emitterRepository.findAllEmitterStartWithByUserId(userIdString)).thenReturn(Map.of(emitterId, emitter));
-		when(notificationRepository.save(any(NotificationEntity.class))).thenReturn(expectedNotification);
-
-		notificationService.sendRegisterNotice(userEntity);
-
-		// then
-		ArgumentCaptor<NotificationEntity> notificationCaptor = ArgumentCaptor.forClass(NotificationEntity.class);
-		verify(notificationRepository).save(notificationCaptor.capture());
-		NotificationEntity capturedNotification = notificationCaptor.getValue();
-
-		assertEquals(expectedNotification.getTitle(), capturedNotification.getTitle());
-		assertEquals(expectedNotification.getContent(), capturedNotification.getContent());
-		assertEquals(expectedNotification.getType(), capturedNotification.getType());
-
-		verify(emitterRepository).findAllEmitterStartWithByUserId(userIdString);
-		verify(emitterRepository).saveEventCache(eq(emitterId), any(NotificationEntity.class));
-		verifyNoMoreInteractions(emitterRepository);
-	}
-
-	@Test
-	@DisplayName("회원가입 알림 전송 실패")
-	void sendRegisterNotification_FailSendNotification() throws IOException {
-		// given
-		Long userId = 1L;
-		String userIdString = "1";
-		String email = "test@example.com";
-		String nickname = "tester";
-		Positions positions = Positions.STUDENT;
-		UserEntity userEntity = UserEntity.of(email, nickname, positions);
-		ReflectionTestUtils.setField(userEntity, "id", userId);
-
-		SseEmitter emitter = mock(SseEmitter.class);
-		String emitterId = "1_12345";
-
-		// when
-		when(emitterRepository.findAllEmitterStartWithByUserId(userIdString)).thenReturn(Map.of(emitterId, emitter));
-		doThrow(new IOException("알림 전송 실패"))
-			.when(emitter).send(any(SseEmitter.SseEventBuilder.class));
-
-		// then
-		assertDoesNotThrow(() -> notificationService.sendRegisterNotice(userEntity));
-
-		verify(emitterRepository).findAllEmitterStartWithByUserId(userIdString);
-		verify(emitterRepository).saveEventCache(eq(emitterId), any(NotificationEntity.class));
-		verify(emitterRepository).deleteById(emitterId);
 		verifyNoMoreInteractions(emitterRepository);
 	}
 

--- a/src/test/java/com/daruda/darudaserver/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/notification/service/NotificationServiceTest.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +22,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.daruda.darudaserver.domain.comment.entity.CommentEntity;
@@ -59,6 +63,23 @@ class NotificationServiceTest {
 
 	@InjectMocks
 	private NotificationService notificationService;
+
+	@BeforeEach
+	void setUp() {
+		TransactionSynchronizationManager.initSynchronization();
+	}
+
+	@AfterEach
+	void tearDown() {
+		TransactionSynchronizationManager.clear();
+	}
+
+	private void triggerAfterCommit() {
+		List<TransactionSynchronization> syncs = TransactionSynchronizationManager.getSynchronizations();
+		for (TransactionSynchronization sync : syncs) {
+			sync.afterCommit();
+		}
+	}
 
 	@Test
 	@DisplayName("SSE 연결 성공 - 신규")
@@ -167,6 +188,7 @@ class NotificationServiceTest {
 		when(emitterRepository.findAllEmitterStartWithByUserId(anyString())).thenReturn(Map.of());
 
 		notificationService.sendCommentNotification(comment);
+		triggerAfterCommit();
 
 		// then
 		// author should be notified, otherCommenter should be notified, commenter should NOT.
@@ -194,6 +216,7 @@ class NotificationServiceTest {
 
 		NoticeRequest noticeRequest = new NoticeRequest(title, url);
 		notificationService.sendNotice(noticeRequest);
+		triggerAfterCommit();
 
 		// then
 		verify(userRepository).findAll(any(Pageable.class));
@@ -239,6 +262,7 @@ class NotificationServiceTest {
 		when(notificationRepository.save(any(NotificationEntity.class))).thenReturn(expectedNotification);
 
 		notificationService.sendBlockNotice(communityBlockNoticeRequest);
+		triggerAfterCommit();
 
 		// then
 		ArgumentCaptor<NotificationEntity> notificationCaptor = ArgumentCaptor.forClass(NotificationEntity.class);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #348

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
###  1. 알림(Notification) 기능 고도화
   - [x] 엔티티 및 DTO 변경: `NotificationEntity`, `NotificationResponse`, `NoticeRequest`에 Notion 링크용 `url` 필드 추가
   - [x] 알림 메시지 포맷 최적화: `NotificationFormat` enum에 `format()` 메서드 및 댓글 케이스별(텍스트/이미지) 템플릿 추가
   - [x] 댓글 알림 대상 확대: 게시글 작성자뿐만 아니라 해당 글의 이전 댓글 작성자들(본인 제외) 모두에게 알림이 가도록 로직 수정
   - [x] 전송 로직 최적화: 멀티 디바이스 접속 사용자의 경우에도 알림 DB 저장이 한 번만 발생하도록 `NotificationService.send()` 메서드 개선
   - [x] 기능 제거: `AuthService` 및 `NotificationService`에서 가입 축하 알림 로직 완전 삭제

###  2. 보안(Security) 아키텍처 정문화
   - [x] 설정 단일화: `JwtAuthenticationFilter`의 경로 체크 로직을 삭제하고, `SecurityConfig`로 모든 보안 정책 일원화
   - [x] 정밀한 권한 통제: 전수 조사를 통해 실제 존재하는 Public API만 `WHITE_LIST`에 등록하고, 상태 변경 요청(POST/PATCH/DELETE)은 인증을 강제하도록 설정
   - [x] 필터 효율화: `@Component` 제거를 통해 필터 중복 등록 방지 및 OPTIONS 요청(CORS) 처리 로직 개선

###  3. 시스템 환경 및 버그 수정
   - [x] 검색 인덱스 자동화: `ElasticsearchIndexInitializer`를 추가하여 서버 구동 시 board, tool 인덱스 자동 생성 및 매핑 적용

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 알림에 URL 필드 추가 — 알림에 링크 표시 및 클릭 가능성 제공

* **Changes**
  * 댓글 알림 대상 확장 — 게시물 작성자 및 다른 댓글 작성자에게도 발송
  * 공지 생성 요청의 두번째 항목이 내용 → URL로 변경 및 URL 유효성 검증 적용
  * 회원가입 시 등록 알림 발송 제거
  * 인증·접근 정책 및 보안 필터 동작 정비
  * 애플리케이션 시작 시 검색 인덱스 초기화 추가
  * 개발/운영 DB 스키마 관리 모드 변경(dev:update, prod:validate)

* **Tests**
  * 알림 관련 테스트 및 시나리오 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->