### PR TITLE
[Feat] 게시글 목록 조회 API에 스크랩 수 반환 (#355)

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/community/dto/res/BoardRes.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/dto/res/BoardRes.java
@@ -21,6 +21,7 @@ public class BoardRes {
 	private List<String> images;
 	private Boolean isScraped;
 	private Long toolId;
+	private Long scrapCount;
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
 	private Timestamp updatedAt;
@@ -39,6 +40,12 @@ public class BoardRes {
 	public static BoardRes of(final Board board, final String toolName, final String toolLogo, final int commentCount,
 		final List<String> images, final Boolean isScraped, final Long toolId) {
 		return getBoardResWithToolId(board, toolName, toolLogo, commentCount, images, isScraped, toolId);
+	}
+
+	public static BoardRes of(final Board board, final String toolName, final String toolLogo, final int commentCount,
+		final List<String> images, final Boolean isScraped, final Long toolId, final Long scrapCount) {
+		return getBoardResWithToolIdAndScrapCount(board, toolName, toolLogo, commentCount, images, isScraped, toolId,
+			scrapCount);
 	}
 
 	public static BoardRes createBoardRes(final Board board, final String toolName, final String toolLogo,
@@ -88,6 +95,25 @@ public class BoardRes {
 			.updatedAt(board.getUpdatedAt())
 			.isScraped(isScraped)
 			.toolId(toolId)
+			.build();
+	}
+
+	public static BoardRes getBoardResWithToolIdAndScrapCount(final Board board, final String toolName,
+		final String toolLogo, final int commentCount, final List<String> images, final Boolean isScraped,
+		final Long toolId, final Long scrapCount) {
+		return BoardRes.builder()
+			.boardId(board.getId())
+			.toolName(toolName)
+			.toolLogo(toolLogo)
+			.author(board.getUser().getNickname())
+			.title(board.getTitle())
+			.content(board.getContent())
+			.images(images)
+			.commentCount(commentCount)
+			.updatedAt(board.getUpdatedAt())
+			.isScraped(isScraped)
+			.toolId(toolId)
+			.scrapCount(scrapCount)
 			.build();
 	}
 

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardScrapRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardScrapRepository.java
@@ -1,6 +1,8 @@
 package com.daruda.darudaserver.domain.community.repository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +29,14 @@ public interface BoardScrapRepository extends JpaRepository<BoardScrap, Long> {
 	void deleteByUserIdAndBoardId(@Param("userId") Long userId, @Param("boardId") Long boardId);
 
 	List<BoardScrap> findAllByBoardId(Long boardId);
+
+	@Query("SELECT bs.board.id, COUNT(bs) FROM BoardScrap bs WHERE bs.board.id IN :boardIds GROUP BY bs.board.id")
+	List<Object[]> countByBoardIds(@Param("boardIds") List<Long> boardIds);
+
+	default Map<Long, Long> countMapByBoardIds(final List<Long> boardIds) {
+		return countByBoardIds(boardIds).stream()
+			.collect(Collectors.toMap(row -> (Long)row[0], row -> (Long)row[1]));
+	}
 
 	@Query(value = "SELECT b.id as boardId, b.title as title, b.content as content, b.updatedAt as updatedAt, "
 		+ "t.toolMainName as toolName, t.toolLogo as toolLogo, "

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -3,6 +3,7 @@ package com.daruda.darudaserver.domain.community.service;
 import static com.daruda.darudaserver.domain.community.entity.QBoard.*;
 import static com.daruda.darudaserver.domain.community.entity.QBoardScrap.*;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -225,6 +226,8 @@ public class BoardService {
 		boolean hasNextPage;
 		long nextCursor;
 		long nextScrapCount = -1L;
+		// board별 스크랩 수. SCRAP/LATEST 분기에서 채우는 경로는 다르지만 두 값의 의미(해당 board의 BoardScrap 총 개수)는 동일해야 한다.
+		Map<Long, Long> scrapCountMap = new HashMap<>();
 
 		if (effectiveSortType == BoardSortType.SCRAP) {
 			if ((lastBoardId == null) ^ (lastScrapCount == null)) {
@@ -265,6 +268,12 @@ public class BoardService {
 			List<Tuple> pagedResults = hasNextPage ? results.subList(0, size) : results;
 			paginatedBoards = pagedResults.stream().map(t -> t.get(board)).toList();
 
+			// 정렬 시 이미 조회한 스크랩 수를 재사용 → 추가 쿼리 없이, 커서(nextScrapCount)와 표시값의 시점도 일치
+			for (Tuple tuple : pagedResults) {
+				Long scrapCount = tuple.get(scrapCountExpr);
+				scrapCountMap.put(tuple.get(board).getId(), scrapCount == null ? 0L : scrapCount);
+			}
+
 			if (hasNextPage) {
 				Tuple lastInPage = pagedResults.get(pagedResults.size() - 1);
 				nextCursor = lastInPage.get(board).getId();
@@ -291,13 +300,13 @@ public class BoardService {
 			hasNextPage = boards.size() > size;
 			paginatedBoards = hasNextPage ? boards.subList(0, size) : boards;
 			nextCursor = hasNextPage ? boards.get(size).getId() : -1L;
-		}
 
-		// 정렬 기준과 무관하게 페이지 게시글들의 스크랩 수를 배치 쿼리로 한 번에 조회 (N+1 방지)
-		List<Long> boardIds = paginatedBoards.stream().map(Board::getId).toList();
-		Map<Long, Long> scrapCountMap = boardIds.isEmpty()
-			? Map.of()
-			: boardScrapRepository.countMapByBoardIds(boardIds);
+			// LATEST 정렬은 스크랩 수를 따로 조회하지 않으므로 배치 쿼리로 한 번에 조회 (N+1 방지)
+			List<Long> boardIds = paginatedBoards.stream().map(Board::getId).toList();
+			if (!boardIds.isEmpty()) {
+				scrapCountMap.putAll(boardScrapRepository.countMapByBoardIds(boardIds));
+			}
+		}
 
 		// 응답 데이터
 		List<BoardRes> boardResList = paginatedBoards.stream()

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -4,6 +4,7 @@ import static com.daruda.darudaserver.domain.community.entity.QBoard.*;
 import static com.daruda.darudaserver.domain.community.entity.QBoardScrap.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -292,6 +293,12 @@ public class BoardService {
 			nextCursor = hasNextPage ? boards.get(size).getId() : -1L;
 		}
 
+		// 정렬 기준과 무관하게 페이지 게시글들의 스크랩 수를 배치 쿼리로 한 번에 조회 (N+1 방지)
+		List<Long> boardIds = paginatedBoards.stream().map(Board::getId).toList();
+		Map<Long, Long> scrapCountMap = boardIds.isEmpty()
+			? Map.of()
+			: boardScrapRepository.countMapByBoardIds(boardIds);
+
 		// 응답 데이터
 		List<BoardRes> boardResList = paginatedBoards.stream()
 			.map(board -> {
@@ -314,7 +321,9 @@ public class BoardService {
 				int commentCount = getCommentCount(board.getId());
 				List<String> boardImages = boardImageService.getBoardImageUrls(board.getId());
 				boolean isScrapped = boardScrapService.isScraped(user, board);
-				return BoardRes.of(board, toolName, toolLogo, commentCount, boardImages, isScrapped, savedToolid);
+				long scrapCount = scrapCountMap.getOrDefault(board.getId(), 0L);
+				return BoardRes.of(board, toolName, toolLogo, commentCount, boardImages, isScrapped, savedToolid,
+					scrapCount);
 			})
 			.toList();
 

--- a/src/test/java/com/daruda/darudaserver/domain/community/controller/BoardControllerTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/community/controller/BoardControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.security.web.method.annotation.AuthenticationPrincipa
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import com.daruda.darudaserver.domain.community.dto.res.BoardRes;
 import com.daruda.darudaserver.domain.community.dto.res.BoardScrapRes;
 import com.daruda.darudaserver.domain.community.dto.res.GetBoardResponse;
 import com.daruda.darudaserver.domain.community.entity.BoardSortType;
@@ -108,6 +109,25 @@ class BoardControllerTest {
 			scrapCountCaptor.capture());
 		org.assertj.core.api.Assertions.assertThat(sortCaptor.getValue()).isEqualTo(BoardSortType.SCRAP);
 		org.assertj.core.api.Assertions.assertThat(scrapCountCaptor.getValue()).isEqualTo(5L);
+	}
+
+	@Test
+	@DisplayName("게시글 리스트 조회: 응답의 각 게시글에 스크랩 수(scrapCount)가 포함된다")
+	void getBoardList_includesScrapCount() throws Exception {
+		// given
+		BoardRes boardRes = BoardRes.builder()
+			.boardId(1L)
+			.scrapCount(7L)
+			.build();
+		GetBoardResponse mockResponse = GetBoardResponse.of(List.of(boardRes), ScrollPaginationDto.of(1L, -1L));
+		when(boardService.getBoardList(any(), any(), any(), anyInt(), any(), any(BoardSortType.class), any()))
+			.thenReturn(mockResponse);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/board")
+				.param("size", "10"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.contents[0].scrapCount").value(7));
 	}
 
 	@Test


### PR DESCRIPTION
## 📣 Related Issue

- close #355

## 📝 Summary

웹 팀 요청에 따라 게시글 목록 조회 API(`GET /api/v1/board`) 응답에 게시글별 스크랩 수(`scrapCount`)를 추가로 반환합니다.

- `BoardRes`에 `scrapCount` 필드 추가 (기존 팩토리 시그니처는 유지, 목록 경로용 오버로드 추가)
- `BoardScrapRepository.countMapByBoardIds`: 페이지 게시글들의 스크랩 수를 `IN` + `GROUP BY` 배치 쿼리로 한 번에 조회 (N+1 방지). `Object[] → Map` 변환은 리포지토리 `default` 메서드에서 캡슐화
- `BoardService.getBoardList`: 정렬 기준(LATEST/SCRAP)과 무관하게 배치 쿼리 **단일 경로**로 스크랩 수를 채움 → "스크랩 수" 정의가 한 곳으로 수렴
- 목록 응답에 `scrapCount`가 직렬화되는지 검증하는 컨트롤러 테스트 추가

## 🙏 Question & PR point


## 📬 Postman

<!-- 로컬 검증: PR CI(./gradlew test) 및 배포 CI(./gradlew clean editorconfigFormat build) 모두 통과 확인 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 게시글 목록 응답에 스크랩 수가 포함됩니다.
  * 각 게시글의 스크랩 수를 함께 조회해 더 풍부한 목록 정보를 제공합니다.

* **버그 수정**
  * 게시글 리스트에서 스크랩 수가 누락되던 문제를 개선했습니다.
  * 목록 조회 시 각 게시글의 스크랩 수를 일괄 반영하도록 변경했습니다.

* **테스트**
  * 게시글 목록 응답에 스크랩 수가 포함되는지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->