### PR TITLE
#359 [Fix] 게시판 작성·수정 서버 오류 수정 및 검색 응답 스크랩 수 추가

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -24,7 +24,7 @@ git status
 ```
 
 - **Never commit secrets, regardless of file name** (`.env`, `private.pem`, `application-*.yml`, `.properties`, `.json`, shell scripts, …). Scan the staged diff for credentials before committing.
-- For commit-split units, see `git-convention`'s "Commit types" section.
+- For commit-split units, see `git-convention`'s "Commit granularity" section — split to the smallest self-contained unit, even within one file.
 
 ## 3. Check the branch
 

--- a/.claude/skills/git-convention/SKILL.md
+++ b/.claude/skills/git-convention/SKILL.md
@@ -65,8 +65,28 @@ Rules:
 - Write the description in **Korean**, ending in a noun form like `~ 추가`, `~ 수정`, `~ 변경`.
 - Wrap code identifiers in backticks: `` `BoardService` ``.
 - The issue number includes `#`, no brackets, and comes first. (It is **not** the `[#355] feat: ...` format.)
-- One commit does one thing. Separate feature and tests where possible.
+- Keep each commit to the **smallest self-contained unit** — split by kind/concern even within one file. See the **Commit granularity** section below.
 - If a body is needed, write it in Korean after a blank line following the title.
+
+## Commit granularity — split to the smallest units
+
+Prefer the **smallest self-contained unit** that still builds and can be reviewed and reverted on its own. Split whenever changes differ in **kind** or **concern** — **even when they touch the same file. Sitting in one file is not a reason to combine them.**
+
+- Two unrelated bug fixes → two `[fix]` commits.
+- Different concerns of one issue → one commit each (`[fix]` vs `[feat]` vs `[refactor]`).
+- Production code and its tests → separate commits (`[feat]`, then `[test]`).
+- Mechanical changes (formatting, renames, import order) → their own `[style]`/`[refactor]` commit, kept out of logic commits.
+
+**How, given no interactive staging** (`git add -p` / `git add -i` are unavailable — see "Git safety rules"): commit **incrementally as you write**, rather than batching every edit and trying to split afterward.
+
+1. Make one logical change.
+2. Verify (`check-all.sh`, or the relevant subset).
+3. Stage only that change's file(s) (`git add <path>`) and commit.
+4. Repeat for the next change.
+
+When several independent changes get interleaved inside one file, treat that as the signal to stop and commit the current one before writing the next.
+
+> Example: a "free-board create" error and an "edit/delete index-lookup" error both live in `BoardService`, but they are independent bugs → commit them separately (`#359 [fix] 자유게시판 작성 오류 수정`, then `#359 [fix] 게시글 수정·삭제 색인 판단 오류 수정`), not as one combined commit.
 
 ## Labels & Assignee (required on both issues and PRs)
 
@@ -106,5 +126,5 @@ The commit author is the actual worker (a teammate); do not credit tools as co-a
 | Direct commit to `develop`/`main` | Forbidden. Always create a working branch first |
 | `git push --force` | Forbidden (`--force-with-lease` only on user request) |
 | Merging your own PR | Forbidden. Only create it, then wait for review |
-| Interactive flags | `git rebase -i`, `git add -i` do not work in this environment |
+| Interactive flags | `git rebase -i`, `git add -i`, `git add -p` do not work in this environment (stage per-file and commit incrementally instead) |
 | `.env`·secrets | Never commit them. Always check the staged list with `git status` |

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardScrapService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardScrapService.java
@@ -1,6 +1,7 @@
 package com.daruda.darudaserver.domain.community.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -59,6 +60,15 @@ public class BoardScrapService {
 			updateSearchIndex(boardId, true);
 			return BoardScrapRes.of(boardId, true);
 		}
+	}
+
+	// board별 스크랩 수 일괄 조회 (검색 등 타 도메인에서 스크랩 수를 표시할 때 사용)
+	@Transactional(readOnly = true)
+	public Map<Long, Long> getScrapCountMap(final List<Long> boardIds) {
+		if (boardIds == null || boardIds.isEmpty()) {
+			return Map.of();
+		}
+		return boardScrapRepository.countMapByBoardIds(boardIds);
 	}
 
 	// 스크랩 여부 확인 (UserEntity 기반)

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -29,7 +29,6 @@ import com.daruda.darudaserver.domain.community.repository.BoardImageRepository;
 import com.daruda.darudaserver.domain.community.repository.BoardRepository;
 import com.daruda.darudaserver.domain.community.repository.BoardScrapRepository;
 import com.daruda.darudaserver.domain.community.util.ValidateBoard;
-import com.daruda.darudaserver.domain.search.document.BoardDocument;
 import com.daruda.darudaserver.domain.search.repository.BoardSearchRepository;
 import com.daruda.darudaserver.domain.tool.entity.Tool;
 import com.daruda.darudaserver.domain.tool.repository.ToolRepository;
@@ -88,10 +87,17 @@ public class BoardService {
 			throw new ForbiddenException(ErrorCode.USER_SUSPENDED);
 		}
 
-		Tool tool = getToolById(boardCreateAndUpdateReq.toolId());
-		Board board = boardCreateAndUpdateReq.isFree()
-			? createFreeBoard(user, boardCreateAndUpdateReq) :
-			createToolBoard(tool, boardCreateAndUpdateReq, user);
+		// 자유 게시판(isFree=true)은 toolId가 없으므로 Tool을 조회하지 않는다. (toolId=null로 조회 시 예외 발생 방지)
+		Board board;
+		Long toolId;
+		if (boardCreateAndUpdateReq.isFree()) {
+			board = createFreeBoard(user, boardCreateAndUpdateReq);
+			toolId = null;
+		} else {
+			Tool tool = getToolById(boardCreateAndUpdateReq.toolId());
+			board = createToolBoard(tool, boardCreateAndUpdateReq, user);
+			toolId = tool.getToolId();
+		}
 
 		// 이미지 처리
 		List<String> imageUrls = processImages(board, boardCreateAndUpdateReq.imageList());
@@ -104,7 +110,7 @@ public class BoardService {
 		String toolName = board.getTool() != null ? board.getTool().getToolMainName() : FREE;
 		String toolLogo = board.getTool() != null ? board.getTool().getToolLogo() : TOOL_LOGO;
 
-		return BoardRes.of(board, toolName, toolLogo, getCommentCount(board.getId()), imageUrls, tool.getToolId());
+		return BoardRes.of(board, toolName, toolLogo, getCommentCount(board.getId()), imageUrls, toolId);
 	}
 
 	// 게시판 업데이트
@@ -118,9 +124,9 @@ public class BoardService {
 			throw new ForbiddenException(ErrorCode.USER_SUSPENDED);
 		}
 
-		boardSearchRepository.findById(boardId.toString())
-			.orElseThrow(() -> new NotFoundException(ErrorCode.BOARD_NOT_FOUND));
-
+		// 게시글 존재 여부는 validateBoardAndUser(DB)로 이미 검증된다.
+		// 검색 색인(ES) 문서 유무로 판단하면 색인 지연/유실 시 정상 게시글도 수정 불가가 되므로 사전 검증하지 않는다.
+		// 수정 후 BoardUpdatedEvent 처리에서 ES 문서를 upsert(save)하여 재색인한다.
 		Tool tool = boardCreateAndUpdateReq.isFree() ? null : getToolById(boardCreateAndUpdateReq.toolId());
 
 		board.update(
@@ -148,8 +154,6 @@ public class BoardService {
 	// 게시판 삭제
 	public void deleteBoard(final Long userId, final Long boardId) {
 		Board board = validateBoardAndUser(userId, boardId);
-		BoardDocument boardDocument = boardSearchRepository.findById(boardId.toString())
-			.orElseThrow(() -> new NotFoundException(ErrorCode.BOARD_NOT_FOUND));
 		deleteOriginImages(boardId);
 
 		List<CommentEntity> commentEntityList = commentRepository.findCommentsByBoardId(boardId);
@@ -164,7 +168,8 @@ public class BoardService {
 			log.info("삭제된 게시글과 연관된 스크랩 데이터를 제거했습니다. Scrap Count: {}", scraps.size());
 		}
 		board.delete();
-		boardSearchRepository.delete(boardDocument);
+		// 검색 색인(ES) 문서가 없어도 삭제가 실패하지 않도록 idempotent하게 처리한다.
+		boardSearchRepository.deleteById(boardId.toString());
 	}
 
 	// 게시판 조회

--- a/src/main/java/com/daruda/darudaserver/domain/search/dto/response/BoardSearchResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/search/dto/response/BoardSearchResponse.java
@@ -19,9 +19,10 @@ public record BoardSearchResponse(
 	Long toolId,
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
 	Date updatedAt,
-	int commentCount
+	int commentCount,
+	Long scrapCount
 ) {
-	public static BoardSearchResponse from(BoardDocument doc) {
+	public static BoardSearchResponse from(BoardDocument doc, final long scrapCount) {
 		return new BoardSearchResponse(
 			Long.valueOf(doc.getId()),
 			doc.getToolMainName(),
@@ -33,7 +34,8 @@ public record BoardSearchResponse(
 			doc.isScraped(),
 			doc.getToolId(),
 			doc.getUpdatedAt(),
-			doc.getCommentCount()
+			doc.getCommentCount(),
+			scrapCount
 		);
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/search/service/BoardSearchService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/search/service/BoardSearchService.java
@@ -1,6 +1,7 @@
 package com.daruda.darudaserver.domain.search.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -10,6 +11,7 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.daruda.darudaserver.domain.community.service.BoardScrapService;
 import com.daruda.darudaserver.domain.search.document.BoardDocument;
 import com.daruda.darudaserver.domain.search.dto.response.BoardSearchResponse;
 import com.daruda.darudaserver.domain.search.dto.response.GetBoardDocumentResponse;
@@ -33,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 public class BoardSearchService {
 
 	private final ElasticsearchTemplate elasticsearchTemplate;
+	private final BoardScrapService boardScrapService;
 
 
 	public GetBoardDocumentResponse searchByTitleAndContentAndTool(String keyword, String nextCursor, int size) {
@@ -102,8 +105,19 @@ public class BoardSearchService {
 
 		SearchHits<BoardDocument> hits = elasticsearchTemplate.search(query, BoardDocument.class);
 
-		List<BoardSearchResponse> boardSearchResponses = hits.getSearchHits().stream()
-			.map(hit -> BoardSearchResponse.from(hit.getContent()))
+		List<BoardDocument> documents = hits.getSearchHits().stream()
+			.map(hit -> hit.getContent())
+			.toList();
+
+		// 스크랩 수는 색인(ES)에 두면 스크랩 변동마다 재색인이 필요해 최신성이 떨어지므로, DB에서 일괄 조회해 채운다.
+		List<Long> boardIds = documents.stream()
+			.map(doc -> Long.valueOf(doc.getId()))
+			.toList();
+		Map<Long, Long> scrapCountMap = boardScrapService.getScrapCountMap(boardIds);
+
+		List<BoardSearchResponse> boardSearchResponses = documents.stream()
+			.map(doc -> BoardSearchResponse.from(doc,
+				scrapCountMap.getOrDefault(Long.valueOf(doc.getId()), 0L)))
 			.toList();
 
 		boolean hasNext = boardSearchResponses.size() > size;


### PR DESCRIPTION
## 📣 Related Issue

- close #359

## 📝 Summary

FE(V2 18차 회의) 피드백으로 확인된 게시판 서버 오류를 수정하고, 검색 응답에 스크랩 수를 추가했습니다.

- **[fix] 자유게시판 작성 오류**: `createBoard`가 자유게시판(`isFree=true`, `toolId` 없음)일 때도 `getToolById(null)`을 호출해 서버 오류가 발생하던 문제 수정. `isFree`일 때 `Tool`을 조회하지 않도록 분기.
- **[fix] 수정·삭제 시 "글을 찾을 수 없음" 오류**: `updateBoard`·`deleteBoard`가 게시글 존재를 검색 색인(ES) 문서 유무로 판단해, 색인 지연·유실 시 정상 게시글도 실패하던 문제 수정. 게시글 존재는 이미 DB(`validateBoardAndUser`)로 검증되고 수정 후 `BoardUpdatedEvent`가 ES를 upsert하므로 사전 검증을 제거하고, 삭제는 `deleteById`로 idempotent 처리.
- **[feat] 검색 응답 스크랩 수**: 게시글 검색(`/api/v1/search/board`) 응답 `BoardSearchResponse`에 `scrapCount` 추가. ES 최신성 문제로 DB에서 일괄 조회하며, 도메인 경계 규칙에 따라 `BoardScrapService.getScrapCountMap`을 통해 조회.
- **[chore] 지침 문서**: `git-convention` 스킬에 `Commit granularity`(최소 커밋 단위) 원칙 추가 및 관련 참조 정합화. (기능/버그와 무관한 문서 개선)

## 🙏 Question & PR point

- 게시글 목록 API의 스크랩 수는 이미 구현돼 있어 이번 변경에는 포함하지 않았습니다.
- 수정·삭제에서 ES 문서 사전 검증을 제거했는데, ES/DB 정합성 보정(재색인) 정책 방향에 대한 의견 부탁드립니다.

## 📬 Postman

> 스크린샷은 별도 첨부가 필요합니다. 로컬 전체 검증(`check-all.sh`)은 통과했습니다.
> editorconfig ✅ · Checkstyle(main·test) ✅ · 전체 테스트 ✅