### PR TITLE
#363 [Fix] 툴·마이페이지 목록 API 응답 오류 4건 수정 및 블로그 메타데이터 보강

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,9 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
+    // HTML parsing (OG metadata)
+    implementation 'org.jsoup:jsoup:1.18.1'
+
     // Sentry
     implementation 'io.sentry:sentry-logback:7.17.0'
     implementation 'com.github.napstr:logback-discord-appender:1.0.0'

--- a/docs/sql/tool_blog_og_metadata.sql
+++ b/docs/sql/tool_blog_og_metadata.sql
@@ -1,0 +1,9 @@
+-- #363 tool_blog OG 메타데이터 컬럼 추가 (prod 배포 전 수동 실행)
+-- prod 는 ddl-auto: validate 이며 마이그레이션 도구가 없으므로 배포 전에 직접 적용한다.
+ALTER TABLE tool_blog
+    ADD COLUMN title              VARCHAR(500)  NULL,
+    ADD COLUMN thumbnail_url      VARCHAR(2000) NULL,
+    ADD COLUMN summary            VARCHAR(2000) NULL,
+    ADD COLUMN site_name          VARCHAR(200)  NULL,
+    ADD COLUMN favicon_url        VARCHAR(2000) NULL,
+    ADD COLUMN metadata_fetched_at DATETIME     NULL;

--- a/src/main/java/com/daruda/darudaserver/domain/admin/service/AdminService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/admin/service/AdminService.java
@@ -41,6 +41,8 @@ import com.daruda.darudaserver.domain.tool.repository.ToolScrapRepository;
 import com.daruda.darudaserver.domain.tool.repository.ToolVideoRepository;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
+import com.daruda.darudaserver.global.scraper.OgMetadata;
+import com.daruda.darudaserver.global.scraper.OgMetadataScraper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -60,6 +62,7 @@ public class AdminService {
 	private final ToolScrapRepository toolScrapRepository;
 	private final ToolLikeRepository toolLikeRepository;
 	private final ToolBlogRepository toolBlogRepository;
+	private final OgMetadataScraper ogMetadataScraper;
 
 	@Transactional
 	public void createTool(CreateToolRequest createToolRequest) {
@@ -116,12 +119,16 @@ public class AdminService {
 			}
 		}
 
-		//ToolBlog 가공
+		//ToolBlog 가공 — 생성 시점에 OG 메타데이터를 1회 스크래핑해 저장한다. 링크 하나가 실패해도 생성은 중단되지 않는다.
 		List<String> blogLinks = createToolRequest.blogLinks();
 		if (blogLinks != null && !blogLinks.isEmpty()) {
 			List<ToolBlog> blogEntities = blogLinks.stream()
 				.filter(link -> link != null && !link.isBlank())
-				.map(link -> ToolBlog.create(link.trim(), savedTool))
+				.map(link -> {
+					String trimmedLink = link.trim();
+					OgMetadata metadata = ogMetadataScraper.fetch(trimmedLink).orElse(null);
+					return ToolBlog.create(trimmedLink, savedTool, metadata);
+				})
 				.toList();
 			if (!blogEntities.isEmpty()) {
 				toolBlogRepository.saveAll(blogEntities);
@@ -293,7 +300,11 @@ public class AdminService {
 			if (!req.blogLinks().isEmpty()) {
 				List<ToolBlog> toSave = req.blogLinks().stream()
 					.filter(link -> link != null && !link.isBlank())
-					.map(link -> ToolBlog.create(link.trim(), tool))
+					.map(link -> {
+						String trimmedLink = link.trim();
+						OgMetadata metadata = ogMetadataScraper.fetch(trimmedLink).orElse(null);
+						return ToolBlog.create(trimmedLink, tool, metadata);
+					})
 					.toList();
 				if (!toSave.isEmpty()) {
 					toolBlogRepository.saveAll(toSave);

--- a/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,8 @@
 package com.daruda.darudaserver.domain.comment.repository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -38,6 +40,15 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	@Query("SELECT COUNT(c) FROM Comment c WHERE c.board.id = :boardId AND c.isDeleted = false")
 	int countByBoardId(@Param("boardId") Long boardId);
+
+	@Query("SELECT c.board.id, COUNT(c) FROM Comment c "
+		+ "WHERE c.board.id IN :boardIds AND c.isDeleted = false GROUP BY c.board.id")
+	List<Object[]> countByBoardIds(@Param("boardIds") List<Long> boardIds);
+
+	default Map<Long, Long> countMapByBoardIds(final List<Long> boardIds) {
+		return countByBoardIds(boardIds).stream()
+			.collect(Collectors.toMap(row -> (Long)row[0], row -> (Long)row[1]));
+	}
 
 	@Query("SELECT DISTINCT c.user FROM Comment c "
 		+ "WHERE c.board.id = :boardId "

--- a/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.daruda.darudaserver.domain.comment.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
@@ -117,8 +118,8 @@ public class CommentService {
 		return new GetCommentRetrieveResponse(items, pageInfo);
 	}
 
-	public int getCommentCount(final Long boardId) {
-		return commentRepository.findCommentsByBoardId(boardId).size();
+	public Map<Long, Long> getCommentCountMap(final List<Long> boardIds) {
+		return boardIds.isEmpty() ? Map.of() : commentRepository.countMapByBoardIds(boardIds);
 	}
 
 	@Transactional

--- a/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
@@ -117,6 +117,10 @@ public class CommentService {
 		return new GetCommentRetrieveResponse(items, pageInfo);
 	}
 
+	public int getCommentCount(final Long boardId) {
+		return commentRepository.findCommentsByBoardId(boardId).size();
+	}
+
 	@Transactional
 	public void deleteComment(Long userId, Long commentId) {
 		// 댓글 유효성 검사

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardScrapRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardScrapRepository.java
@@ -38,9 +38,9 @@ public interface BoardScrapRepository extends JpaRepository<BoardScrap, Long> {
 	}
 
 	@Query(value = "SELECT b.id as boardId, b.title as title, b.content as content, b.updatedAt as updatedAt, "
-		+ "t.toolMainName as toolName, t.toolLogo as toolLogo, "
+		+ "u.nickname as author, t.toolMainName as toolName, t.toolLogo as toolLogo, t.toolId as toolId, "
 		+ "(SELECT COUNT(s) FROM BoardScrap s WHERE s.board.id = b.id) as scrapCount "
-		+ "FROM BoardScrap bs JOIN bs.board b LEFT JOIN b.tool t "
+		+ "FROM BoardScrap bs JOIN bs.board b JOIN b.user u LEFT JOIN b.tool t "
 		+ "WHERE bs.user.id = :userId AND b.delYn = false",
 		countQuery = "SELECT COUNT(bs) FROM BoardScrap bs WHERE bs.user.id = :userId AND bs.board.delYn = false")
 	Page<ScrapBoardProjection> findScrapBoardsWithCount(@Param("userId") Long userId, Pageable pageable);

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/ScrapBoardProjection.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/ScrapBoardProjection.java
@@ -11,9 +11,13 @@ public interface ScrapBoardProjection {
 
 	LocalDateTime getUpdatedAt();
 
+	String getAuthor();
+
 	String getToolName();
 
 	String getToolLogo();
+
+	Long getToolId();
 
 	Long getScrapCount();
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardScrapService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardScrapService.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.daruda.darudaserver.domain.comment.service.CommentService;
 import com.daruda.darudaserver.domain.community.dto.response.BoardScrapResponse;
 import com.daruda.darudaserver.domain.community.entity.Board;
 import com.daruda.darudaserver.domain.community.entity.BoardScrap;
@@ -42,6 +43,8 @@ public class BoardScrapService {
 	private final BoardSearchRepository boardSearchRepository;
 	private final ValidateBoard validateBoard;
 	private final BoardScrapInternalService boardScrapInternalService;
+	private final BoardImageService boardImageService;
+	private final CommentService commentService;
 
 	// 스크랩 토글 (존재하면 삭제, 없으면 생성)
 	@Transactional
@@ -90,13 +93,17 @@ public class BoardScrapService {
 		List<ScrapBoardsResponse> scrapBoardsResponses = boardScraps.getContent().stream()
 			.map(projection -> ScrapBoardsResponse.of(
 				projection.getBoardId(),
-				projection.getTitle(),
-				projection.getContent(),
-				projection.getUpdatedAt(),
 				projection.getToolName() != null ? projection.getToolName() : FREE,
 				projection.getToolLogo() != null ? projection.getToolLogo() : TOOL_LOGO,
+				projection.getAuthor(),
+				projection.getTitle(),
+				projection.getContent(),
+				boardImageService.getBoardImageUrls(projection.getBoardId()),
 				true,
-				projection.getScrapCount()
+				projection.getToolId(),
+				projection.getScrapCount(),
+				projection.getUpdatedAt(),
+				commentService.getCommentCount(projection.getBoardId())
 			))
 			.toList();
 

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardScrapService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardScrapService.java
@@ -90,6 +90,10 @@ public class BoardScrapService {
 		validateBoard.validateUser(userId);
 
 		Page<ScrapBoardProjection> boardScraps = boardScrapRepository.findScrapBoardsWithCount(userId, pageable);
+		List<Long> boardIds = boardScraps.getContent().stream()
+			.map(ScrapBoardProjection::getBoardId)
+			.toList();
+		Map<Long, Long> commentCountMap = commentService.getCommentCountMap(boardIds);
 		List<ScrapBoardsResponse> scrapBoardsResponses = boardScraps.getContent().stream()
 			.map(projection -> ScrapBoardsResponse.of(
 				projection.getBoardId(),
@@ -103,7 +107,7 @@ public class BoardScrapService {
 				projection.getToolId(),
 				projection.getScrapCount(),
 				projection.getUpdatedAt(),
-				commentService.getCommentCount(projection.getBoardId())
+				commentCountMap.getOrDefault(projection.getBoardId(), 0L).intValue()
 			))
 			.toList();
 

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -386,6 +386,9 @@ public class BoardService {
 		// 스크랩 수는 배치 쿼리로 한 번에 조회 (N+1 방지)
 		Map<Long, Long> scrapCountMap = boardIds.isEmpty()
 			? Map.of() : boardScrapRepository.countMapByBoardIds(boardIds);
+		// 댓글 수도 배치 쿼리로 한 번에 조회 (N+1 방지)
+		Map<Long, Long> commentCountMap = boardIds.isEmpty()
+			? Map.of() : commentRepository.countMapByBoardIds(boardIds);
 
 		List<BoardResponse> boardResList = content.stream()
 			.map(board -> {
@@ -393,7 +396,7 @@ public class BoardService {
 				Long savedToolId = board.getTool() != null ? board.getTool().getToolId() : null;
 				String toolName = board.getTool() != null ? board.getTool().getToolMainName() : FREE;
 				String toolLogo = board.getTool() != null ? board.getTool().getToolLogo() : TOOL_LOGO;
-				int commentCount = getCommentCount(board.getId());
+				int commentCount = commentCountMap.getOrDefault(board.getId(), 0L).intValue();
 				List<String> images = boardImageService.getBoardImageUrls(board.getId());
 				boolean isScraped = boardScrapService.isScraped(user, board);
 				long scrapCount = scrapCountMap.getOrDefault(board.getId(), 0L);

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -179,17 +179,6 @@ public class BoardService {
 		return BoardResponse.of(board, toolName, toolLogo, getCommentCount(boardId), imageUrls, isScraped, toolId);
 	}
 
-	// 내가 쓴  게시판 조회
-	public BoardResponse getMyBoard(final User user, final Long boardId) {
-		Board board = getBoardById(boardId);
-		List<String> imageUrls = boardImageService.getBoardImageUrls(boardId);
-		String toolName = board.getTool() != null ? board.getTool().getToolMainName() : FREE;
-		String toolLogo = board.getTool() != null ? board.getTool().getToolLogo() : TOOL_LOGO;
-
-		Boolean isScraped = boardScrapService.isScraped(user, board);
-		return BoardResponse.of(board, toolName, toolLogo, getCommentCount(boardId), imageUrls, isScraped);
-	}
-
 	public GetBoardResponse getBoardList(final Long userIdOrNull, final Boolean noTopic, final Long toolId,
 		final int size, final Long lastBoardId, final BoardSortType sortType, final Long lastScrapCount) {
 
@@ -391,8 +380,26 @@ public class BoardService {
 		log.debug("사용자를 조회합니다, {}", userIdOrNull);
 		Page<Board> boards = boardRepository.findAllByUserIdAndDelYnFalse(userIdOrNull, pageable);
 		User user = getUser(userIdOrNull);
-		List<BoardResponse> boardResList = boards.getContent().stream()
-			.map(board -> getMyBoard(user, board.getId()))
+
+		List<Board> content = boards.getContent();
+		List<Long> boardIds = content.stream().map(Board::getId).toList();
+		// 스크랩 수는 배치 쿼리로 한 번에 조회 (N+1 방지)
+		Map<Long, Long> scrapCountMap = boardIds.isEmpty()
+			? Map.of() : boardScrapRepository.countMapByBoardIds(boardIds);
+
+		List<BoardResponse> boardResList = content.stream()
+			.map(board -> {
+				// 자유 게시판은 tool이 없으므로 toolId는 nullable
+				Long savedToolId = board.getTool() != null ? board.getTool().getToolId() : null;
+				String toolName = board.getTool() != null ? board.getTool().getToolMainName() : FREE;
+				String toolLogo = board.getTool() != null ? board.getTool().getToolLogo() : TOOL_LOGO;
+				int commentCount = getCommentCount(board.getId());
+				List<String> images = boardImageService.getBoardImageUrls(board.getId());
+				boolean isScraped = boardScrapService.isScraped(user, board);
+				long scrapCount = scrapCountMap.getOrDefault(board.getId(), 0L);
+				return BoardResponse.of(board, toolName, toolLogo, commentCount, images, isScraped, savedToolId,
+					scrapCount);
+			})
 			.toList();
 
 		PagenationDto pageInfo = PagenationDto.of(pageable.getPageNumber(), pageable.getPageSize(),

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.daruda.darudaserver.domain.comment.entity.Comment;
 import com.daruda.darudaserver.domain.comment.repository.CommentRepository;
+import com.daruda.darudaserver.domain.comment.service.CommentService;
 import com.daruda.darudaserver.domain.community.dto.request.BoardCreateAndUpdateRequest;
 import com.daruda.darudaserver.domain.community.dto.response.BoardResponse;
 import com.daruda.darudaserver.domain.community.dto.response.GetBoardResponse;
@@ -64,6 +65,7 @@ public class BoardService {
 	private final BoardScrapService boardScrapService;
 	private final ToolRepository toolRepository;
 	private final CommentRepository commentRepository;
+	private final CommentService commentService;
 	private final ValidateBoard validateBoard;
 	private final BoardSearchRepository boardSearchRepository;
 	private final ApplicationEventPublisher eventPublisher;
@@ -386,9 +388,8 @@ public class BoardService {
 		// 스크랩 수는 배치 쿼리로 한 번에 조회 (N+1 방지)
 		Map<Long, Long> scrapCountMap = boardIds.isEmpty()
 			? Map.of() : boardScrapRepository.countMapByBoardIds(boardIds);
-		// 댓글 수도 배치 쿼리로 한 번에 조회 (N+1 방지)
-		Map<Long, Long> commentCountMap = boardIds.isEmpty()
-			? Map.of() : commentRepository.countMapByBoardIds(boardIds);
+		// 댓글 수도 배치로 한 번에 조회 (N+1 방지). 도메인 경계상 `CommentService`를 경유한다.
+		Map<Long, Long> commentCountMap = commentService.getCommentCountMap(boardIds);
 
 		List<BoardResponse> boardResList = content.stream()
 			.map(board -> {

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolBlogResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolBlogResponse.java
@@ -7,12 +7,22 @@ import lombok.Builder;
 @Builder
 public record ToolBlogResponse(
 	Long blogId,
-	String blogUrl
+	String blogUrl,
+	String title,
+	String thumbnailUrl,
+	String summary,
+	String siteName,
+	String faviconUrl
 ) {
 	public static ToolBlogResponse from(ToolBlog toolBlog) {
 		return ToolBlogResponse.builder()
 			.blogId(toolBlog.getBlogId())
 			.blogUrl(toolBlog.getBlogUrl())
+			.title(toolBlog.getTitle())
+			.thumbnailUrl(toolBlog.getThumbnailUrl())
+			.summary(toolBlog.getSummary())
+			.siteName(toolBlog.getSiteName())
+			.faviconUrl(toolBlog.getFaviconUrl())
 			.build();
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolBlog.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolBlog.java
@@ -1,5 +1,9 @@
 package com.daruda.darudaserver.domain.tool.entity;
 
+import java.time.LocalDateTime;
+
+import com.daruda.darudaserver.global.scraper.OgMetadata;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -30,14 +34,61 @@ public class ToolBlog {
 	@Column(name = "blog_url", nullable = false, length = 50000)
 	private String blogUrl;
 
+	@Column(name = "title", length = 500)
+	private String title;
+
+	@Column(name = "thumbnail_url", length = 2000)
+	private String thumbnailUrl;
+
+	@Column(name = "summary", length = 2000)
+	private String summary;
+
+	@Column(name = "site_name", length = 200)
+	private String siteName;
+
+	@Column(name = "favicon_url", length = 2000)
+	private String faviconUrl;
+
+	@Column(name = "metadata_fetched_at")
+	private LocalDateTime metadataFetchedAt;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "tool_id", nullable = false)
 	private Tool tool;
 
-	public static ToolBlog create(String blogUrl, Tool tool) {
-		return ToolBlog.builder()
+	public static ToolBlog create(final String blogUrl, final Tool tool, final OgMetadata metadata) {
+		// AdminService 는 create 전에 항상 fetch() 를 시도하므로 metadata 가 null 이어도 "시도했음"으로 본다.
+		ToolBlogBuilder builder = ToolBlog.builder()
 			.blogUrl(blogUrl)
 			.tool(tool)
-			.build();
+			.metadataFetchedAt(LocalDateTime.now());
+		if (metadata != null) {
+			builder.title(metadata.title())
+				.thumbnailUrl(metadata.thumbnailUrl())
+				.summary(metadata.summary())
+				.siteName(metadata.siteName())
+				.faviconUrl(metadata.faviconUrl());
+		}
+		return builder.build();
+	}
+
+	/**
+	 * 조회 시점 지연 백필용. 이미 영속 상태인 엔티티에 스크래핑 결과를 반영한다.
+	 * 스크래핑이 실패해(metadata == null) 값이 비어도 "시도 시각"은 기록하므로 재조회 시 다시 긁지 않는다.
+	 */
+	public void applyMetadata(final OgMetadata metadata) {
+		this.metadataFetchedAt = LocalDateTime.now();
+		if (metadata == null) {
+			return;
+		}
+		this.title = metadata.title();
+		this.thumbnailUrl = metadata.thumbnailUrl();
+		this.summary = metadata.summary();
+		this.siteName = metadata.siteName();
+		this.faviconUrl = metadata.faviconUrl();
+	}
+
+	public boolean needsMetadataBackfill() {
+		return this.metadataFetchedAt == null;
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolBlog.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolBlog.java
@@ -26,6 +26,13 @@ import lombok.NoArgsConstructor;
 @Builder
 @Table(name = "tool_blog")
 public class ToolBlog {
+
+	private static final int TITLE_MAX_LENGTH = 500;
+	private static final int THUMBNAIL_URL_MAX_LENGTH = 2000;
+	private static final int SUMMARY_MAX_LENGTH = 2000;
+	private static final int SITE_NAME_MAX_LENGTH = 200;
+	private static final int FAVICON_URL_MAX_LENGTH = 2000;
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "tool_blog_id")
@@ -34,19 +41,19 @@ public class ToolBlog {
 	@Column(name = "blog_url", nullable = false, length = 50000)
 	private String blogUrl;
 
-	@Column(name = "title", length = 500)
+	@Column(name = "title", length = TITLE_MAX_LENGTH)
 	private String title;
 
-	@Column(name = "thumbnail_url", length = 2000)
+	@Column(name = "thumbnail_url", length = THUMBNAIL_URL_MAX_LENGTH)
 	private String thumbnailUrl;
 
-	@Column(name = "summary", length = 2000)
+	@Column(name = "summary", length = SUMMARY_MAX_LENGTH)
 	private String summary;
 
-	@Column(name = "site_name", length = 200)
+	@Column(name = "site_name", length = SITE_NAME_MAX_LENGTH)
 	private String siteName;
 
-	@Column(name = "favicon_url", length = 2000)
+	@Column(name = "favicon_url", length = FAVICON_URL_MAX_LENGTH)
 	private String faviconUrl;
 
 	@Column(name = "metadata_fetched_at")
@@ -63,11 +70,11 @@ public class ToolBlog {
 			.tool(tool)
 			.metadataFetchedAt(LocalDateTime.now());
 		if (metadata != null) {
-			builder.title(metadata.title())
-				.thumbnailUrl(metadata.thumbnailUrl())
-				.summary(metadata.summary())
-				.siteName(metadata.siteName())
-				.faviconUrl(metadata.faviconUrl());
+			builder.title(clampText(metadata.title(), TITLE_MAX_LENGTH))
+				.thumbnailUrl(clampUrl(metadata.thumbnailUrl(), THUMBNAIL_URL_MAX_LENGTH))
+				.summary(clampText(metadata.summary(), SUMMARY_MAX_LENGTH))
+				.siteName(clampText(metadata.siteName(), SITE_NAME_MAX_LENGTH))
+				.faviconUrl(clampUrl(metadata.faviconUrl(), FAVICON_URL_MAX_LENGTH));
 		}
 		return builder.build();
 	}
@@ -81,14 +88,27 @@ public class ToolBlog {
 		if (metadata == null) {
 			return;
 		}
-		this.title = metadata.title();
-		this.thumbnailUrl = metadata.thumbnailUrl();
-		this.summary = metadata.summary();
-		this.siteName = metadata.siteName();
-		this.faviconUrl = metadata.faviconUrl();
+		this.title = clampText(metadata.title(), TITLE_MAX_LENGTH);
+		this.thumbnailUrl = clampUrl(metadata.thumbnailUrl(), THUMBNAIL_URL_MAX_LENGTH);
+		this.summary = clampText(metadata.summary(), SUMMARY_MAX_LENGTH);
+		this.siteName = clampText(metadata.siteName(), SITE_NAME_MAX_LENGTH);
+		this.faviconUrl = clampUrl(metadata.faviconUrl(), FAVICON_URL_MAX_LENGTH);
 	}
 
 	public boolean needsMetadataBackfill() {
 		return this.metadataFetchedAt == null;
+	}
+
+	// 컬럼 길이를 초과한 텍스트는 잘라서 저장한다(플러시 시 DB 에러 방지).
+	private static String clampText(final String value, final int max) {
+		if (value == null) {
+			return null;
+		}
+		return value.length() > max ? value.substring(0, max) : value;
+	}
+
+	// 컬럼 길이를 초과한 URL 은 잘라 쓰면 깨진 링크가 되므로 통째로 버린다.
+	private static String clampUrl(final String value, final int max) {
+		return (value == null || value.length() > max) ? null : value;
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolBlogMetadataService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolBlogMetadataService.java
@@ -1,0 +1,48 @@
+package com.daruda.darudaserver.domain.tool.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.daruda.darudaserver.domain.tool.dto.response.ToolBlogResponse;
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import com.daruda.darudaserver.domain.tool.entity.ToolBlog;
+import com.daruda.darudaserver.domain.tool.repository.ToolBlogRepository;
+import com.daruda.darudaserver.global.scraper.OgMetadataScraper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 블로그 메타데이터 지연 백필 전용 빈.
+ * {@code ToolService}의 조회는 {@code readOnly} 트랜잭션이므로, 여기서 쓰기를 별도 트랜잭션으로 분리한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ToolBlogMetadataService {
+
+	private final ToolBlogRepository toolBlogRepository;
+	private final OgMetadataScraper ogMetadataScraper;
+
+	/**
+	 * 메타데이터가 비어 있는 블로그 행을 스크래핑해 채운 뒤 툴의 전체 블로그를 응답 DTO로 반환한다.
+	 * 스크래핑 실패는 무시하고 해당 행의 메타데이터는 null로 남긴다(GET 실패 아님).
+	 */
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public List<ToolBlogResponse> backfillAndGet(final Tool tool) {
+		List<ToolBlog> blogList = toolBlogRepository.findAllByTool(tool);
+		for (ToolBlog blog : blogList) {
+			if (!blog.needsMetadataBackfill()) {
+				continue;
+			}
+			// 실패해도 applyMetadata(null) 로 "시도 시각"을 남겨 다음 조회에서 재시도하지 않게 한다.
+			blog.applyMetadata(ogMetadataScraper.fetch(blog.getBlogUrl()).orElse(null));
+		}
+		return blogList.stream()
+			.map(ToolBlogResponse::from)
+			.toList();
+	}
+}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolBlogMetadataService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolBlogMetadataService.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ToolBlogMetadataService {
 
 	private final ToolBlogRepository toolBlogRepository;

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -218,13 +218,19 @@ public class ToolService {
 			nextCursor = filteredTools.get(lastIndex).getToolId(); // 다음 `toolId` 설정
 		}
 
+		//  키워드 일괄 조회 (키워드가 없는 툴은 빈 목록으로 처리)
+		List<Long> toolIds = paginatedTools.stream()
+			.map(Tool::getToolId)
+			.toList();
+		Map<Long, List<String>> keywordMap = getKeywordsBatch(toolIds);
+
 		//  응답 데이터 변환
 		List<ToolResponse> toolResponses = paginatedTools.stream()
 			.map(tool -> {
 				boolean isScraped = user != null && toolScrapRepository.findByUserAndTool(user, tool)
 					.map(toolScrap -> !toolScrap.isDelYn())
 					.orElse(false);
-				return ToolResponse.of(tool, convertToKeywordRes(tool), isScraped);
+				return ToolResponse.of(tool, keywordMap.getOrDefault(tool.getToolId(), List.of()), isScraped);
 			})
 			.toList();
 

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -73,6 +73,7 @@ public class ToolService {
 	private final UserRepository userRepository;
 	private final ToolBlogRepository toolBlogRepository;
 	private final ToolLikeInternalService toolLikeInternalService;
+	private final ToolBlogMetadataService toolBlogMetadataService;
 
 	@Transactional
 	public ToolDetailGetResponse getToolDetail(Long userId, final Long toolId) {
@@ -312,7 +313,12 @@ public class ToolService {
 	private List<ToolBlogResponse> getBlogByTool(final Tool tool) {
 		log.debug("툴에 연결된 블로그 정보를 조회합니다. toolId={}", tool.getToolId());
 		List<ToolBlog> blogList = toolBlogRepository.findAllByTool(tool);
-		validateList(blogList);
+		// 블로그가 없으면 빈 목록을 반환한다(404 아님).
+		boolean needsBackfill = blogList.stream().anyMatch(ToolBlog::needsMetadataBackfill);
+		if (needsBackfill) {
+			// 아직 스크래핑을 시도한 적 없는 행은 별도 트랜잭션에서 스크래핑 후 저장한다(조회 트랜잭션은 readOnly 유지).
+			return toolBlogMetadataService.backfillAndGet(tool);
+		}
 		return blogList.stream()
 			.map(ToolBlogResponse::from)
 			.toList();

--- a/src/main/java/com/daruda/darudaserver/domain/user/dto/response/ScrapBoardsResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/dto/response/ScrapBoardsResponse.java
@@ -1,6 +1,7 @@
 package com.daruda.darudaserver.domain.user.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -9,26 +10,35 @@ import lombok.Builder;
 @Builder
 public record ScrapBoardsResponse(
 	Long boardId,
-	String title,
-	String content,
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
-	LocalDateTime updatedAt,
 	String toolName,
 	String toolLogo,
-	Boolean isScrapped,
-	Long scrapCount
+	String author,
+	String title,
+	String content,
+	List<String> images,
+	Boolean isScraped,
+	Long toolId,
+	Long scrapCount,
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
+	LocalDateTime updatedAt,
+	int commentCount
 ) {
-	public static ScrapBoardsResponse of(Long boardId, String title, String content, LocalDateTime updatedAt,
-		String toolName, String toolLogo, Boolean isScrapped, Long scrapCount) {
+	public static ScrapBoardsResponse of(Long boardId, String toolName, String toolLogo, String author, String title,
+		String content, List<String> images, Boolean isScraped, Long toolId, Long scrapCount, LocalDateTime updatedAt,
+		int commentCount) {
 		return ScrapBoardsResponse.builder()
 			.boardId(boardId)
-			.title(title)
-			.content(content)
-			.updatedAt(updatedAt)
 			.toolName(toolName)
 			.toolLogo(toolLogo)
-			.isScrapped(isScrapped)
+			.author(author)
+			.title(title)
+			.content(content)
+			.images(images)
+			.isScraped(isScraped)
+			.toolId(toolId)
 			.scrapCount(scrapCount)
+			.updatedAt(updatedAt)
+			.commentCount(commentCount)
 			.build();
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/global/scraper/OgMetadata.java
+++ b/src/main/java/com/daruda/darudaserver/global/scraper/OgMetadata.java
@@ -1,0 +1,10 @@
+package com.daruda.darudaserver.global.scraper;
+
+public record OgMetadata(
+	String title,
+	String thumbnailUrl,
+	String summary,
+	String siteName,
+	String faviconUrl
+) {
+}

--- a/src/main/java/com/daruda/darudaserver/global/scraper/OgMetadataScraper.java
+++ b/src/main/java/com/daruda/darudaserver/global/scraper/OgMetadataScraper.java
@@ -1,0 +1,101 @@
+package com.daruda.darudaserver.global.scraper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 블로그 URL의 Open Graph / <meta> 태그를 긁어 카드 노출용 메타데이터를 만든다.
+ * 모든 수집은 best-effort다. 실패 시 예외를 전파하지 않고 빈 값을 돌려준다.
+ */
+@Slf4j
+@Component
+public class OgMetadataScraper {
+
+	private static final int TIMEOUT_MS = 3000;
+	private static final int MAX_BODY_SIZE = 2 * 1024 * 1024;
+	private static final String USER_AGENT = "Mozilla/5.0 (compatible; DarudaBot/1.0)";
+	private static final String FAVICON_SELECTOR = "link[rel~=(?i)(shortcut )?icon]";
+
+	public Optional<OgMetadata> fetch(final String url) {
+		if (url == null || url.isBlank()) {
+			return Optional.empty();
+		}
+		try {
+			Document document = Jsoup.connect(url)
+				.timeout(TIMEOUT_MS)
+				.followRedirects(true)
+				.ignoreHttpErrors(true)
+				.userAgent(USER_AGENT)
+				.maxBodySize(MAX_BODY_SIZE)
+				.get();
+			return Optional.of(parse(document, url));
+		} catch (IOException | RuntimeException e) {
+			log.warn("OG 메타데이터 수집 실패: url={}", url, e);
+			return Optional.empty();
+		}
+	}
+
+	public OgMetadata parse(final Document doc, final String pageUrl) {
+		String title = firstNonBlank(
+			attr(doc, "meta[property=og:title]", "content"),
+			doc.title()
+		);
+		String thumbnailUrl = firstNonBlank(
+			attr(doc, "meta[property=og:image]", "abs:content"),
+			attr(doc, "meta[name=twitter:image]", "abs:content")
+		);
+		String summary = firstNonBlank(
+			attr(doc, "meta[property=og:description]", "content"),
+			attr(doc, "meta[name=description]", "content")
+		);
+		String siteName = firstNonBlank(
+			attr(doc, "meta[property=og:site_name]", "content"),
+			host(pageUrl)
+		);
+		String faviconUrl = firstNonBlank(
+			attr(doc, FAVICON_SELECTOR, "abs:href"),
+			defaultFavicon(pageUrl)
+		);
+		return new OgMetadata(title, thumbnailUrl, summary, siteName, faviconUrl);
+	}
+
+	private static String attr(final Document doc, final String cssQuery, final String attributeKey) {
+		return doc.select(cssQuery).attr(attributeKey);
+	}
+
+	private static String firstNonBlank(final String... values) {
+		for (String value : values) {
+			if (value != null && !value.isBlank()) {
+				return value.trim();
+			}
+		}
+		return null;
+	}
+
+	private static String host(final String pageUrl) {
+		try {
+			return URI.create(pageUrl).getHost();
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+	}
+
+	private static String defaultFavicon(final String pageUrl) {
+		try {
+			URI uri = URI.create(pageUrl);
+			if (uri.getScheme() == null || uri.getHost() == null) {
+				return null;
+			}
+			return uri.getScheme() + "://" + uri.getHost() + "/favicon.ico";
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+	}
+}

--- a/src/main/java/com/daruda/darudaserver/global/scraper/OgMetadataScraper.java
+++ b/src/main/java/com/daruda/darudaserver/global/scraper/OgMetadataScraper.java
@@ -1,6 +1,7 @@
 package com.daruda.darudaserver.global.scraper;
 
 import java.io.IOException;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -97,7 +98,7 @@ public class OgMetadataScraper {
 		try {
 			for (InetAddress addr : InetAddress.getAllByName(host)) {
 				if (addr.isLoopbackAddress() || addr.isAnyLocalAddress() || addr.isLinkLocalAddress()
-					|| addr.isSiteLocalAddress() || addr.isMulticastAddress()) {
+					|| addr.isSiteLocalAddress() || addr.isMulticastAddress() || isUniqueLocalIpv6(addr)) {
 					return false;
 				}
 			}
@@ -105,6 +106,13 @@ public class OgMetadataScraper {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * IPv6 Unique Local Address(`fc00::/7`) 여부. `isSiteLocalAddress()`가 커버하지 않는 사설 대역이다.
+	 */
+	private static boolean isUniqueLocalIpv6(final InetAddress addr) {
+		return addr instanceof Inet6Address && (addr.getAddress()[0] & 0xFE) == 0xFC;
 	}
 
 	private static String attr(final Document doc, final String cssQuery, final String attributeKey) {

--- a/src/main/java/com/daruda/darudaserver/global/scraper/OgMetadataScraper.java
+++ b/src/main/java/com/daruda/darudaserver/global/scraper/OgMetadataScraper.java
@@ -1,7 +1,9 @@
 package com.daruda.darudaserver.global.scraper;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.util.Optional;
 
 import org.jsoup.Jsoup;
@@ -22,9 +24,15 @@ public class OgMetadataScraper {
 	private static final int MAX_BODY_SIZE = 2 * 1024 * 1024;
 	private static final String USER_AGENT = "Mozilla/5.0 (compatible; DarudaBot/1.0)";
 	private static final String FAVICON_SELECTOR = "link[rel~=(?i)(shortcut )?icon]";
+	private static final String UNKNOWN_HOST = "unknown";
 
 	public Optional<OgMetadata> fetch(final String url) {
 		if (url == null || url.isBlank()) {
+			return Optional.empty();
+		}
+		// 최초 URL만 검증한다. 리다이렉트 경유지는 재검증하지 않는다(수용된 범위).
+		if (!isSafePublicHttpUrl(url)) {
+			log.warn("차단된 호스트로의 스크래핑 시도: host={}", safeHost(url));
 			return Optional.empty();
 		}
 		try {
@@ -37,7 +45,7 @@ public class OgMetadataScraper {
 				.get();
 			return Optional.of(parse(document, url));
 		} catch (IOException | RuntimeException e) {
-			log.warn("OG 메타데이터 수집 실패: url={}", url, e);
+			log.warn("OG 메타데이터 수집 실패: host={}", safeHost(url), e);
 			return Optional.empty();
 		}
 	}
@@ -66,6 +74,38 @@ public class OgMetadataScraper {
 		return new OgMetadata(title, thumbnailUrl, summary, siteName, faviconUrl);
 	}
 
+	/**
+	 * 스크래핑 대상 URL이 공개 인터넷상의 http(s) 주소인지 가볍게 검증한다(SSRF 완화).
+	 * 최초 URL만 검사하며, 리다이렉트 홉은 재검사하지 않는다(수용된 범위). package-private: 단위 테스트용.
+	 */
+	static boolean isSafePublicHttpUrl(final String url) {
+		final URI uri;
+		try {
+			uri = URI.create(url.trim());
+		} catch (IllegalArgumentException e) {
+			return false;
+		}
+		String scheme = uri.getScheme();
+		if (scheme == null || (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme))) {
+			return false;
+		}
+		String host = uri.getHost();
+		if (host == null || "localhost".equalsIgnoreCase(host)) {
+			return false;
+		}
+		try {
+			for (InetAddress addr : InetAddress.getAllByName(host)) {
+				if (addr.isLoopbackAddress() || addr.isAnyLocalAddress() || addr.isLinkLocalAddress()
+					|| addr.isSiteLocalAddress() || addr.isMulticastAddress()) {
+					return false;
+				}
+			}
+		} catch (UnknownHostException e) {
+			return false;
+		}
+		return true;
+	}
+
 	private static String attr(final Document doc, final String cssQuery, final String attributeKey) {
 		return doc.select(cssQuery).attr(attributeKey);
 	}
@@ -85,6 +125,11 @@ public class OgMetadataScraper {
 		} catch (IllegalArgumentException e) {
 			return null;
 		}
+	}
+
+	private static String safeHost(final String url) {
+		String host = host(url);
+		return host != null ? host : UNKNOWN_HOST;
 	}
 
 	private static String defaultFavicon(final String pageUrl) {

--- a/src/main/java/com/daruda/darudaserver/global/scraper/OgMetadataScraper.java
+++ b/src/main/java/com/daruda/darudaserver/global/scraper/OgMetadataScraper.java
@@ -43,7 +43,8 @@ public class OgMetadataScraper {
 				.userAgent(USER_AGENT)
 				.maxBodySize(MAX_BODY_SIZE)
 				.get();
-			return Optional.of(parse(document, url));
+			String finalUrl = firstNonBlank(document.location(), url);
+			return Optional.of(parse(document, finalUrl));
 		} catch (IOException | RuntimeException e) {
 			log.warn("OG 메타데이터 수집 실패: host={}", safeHost(url), e);
 			return Optional.empty();
@@ -138,7 +139,8 @@ public class OgMetadataScraper {
 			if (uri.getScheme() == null || uri.getHost() == null) {
 				return null;
 			}
-			return uri.getScheme() + "://" + uri.getHost() + "/favicon.ico";
+			// resolve 로 절대 URI에 맞추면 포트(:8080 등)가 보존된다.
+			return uri.resolve("/favicon.ico").toString();
 		} catch (IllegalArgumentException e) {
 			return null;
 		}

--- a/src/test/java/com/daruda/darudaserver/domain/community/service/BoardScrapServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/community/service/BoardScrapServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -165,7 +166,7 @@ class BoardScrapServiceTest {
 		doNothing().when(validateBoard).validateUser(userId);
 		given(boardScrapRepository.findScrapBoardsWithCount(userId, pageable)).willReturn(projectionPage);
 		given(boardImageService.getBoardImageUrls(1L)).willReturn(List.of("https://image1.png"));
-		given(commentService.getCommentCount(1L)).willReturn(3);
+		given(commentService.getCommentCountMap(anyList())).willReturn(Map.of(1L, 3L));
 
 		// when
 		ScrapBoardsRetrieveResponse result = boardScrapService.getScrapBoards(userId, pageable);
@@ -207,7 +208,7 @@ class BoardScrapServiceTest {
 		doNothing().when(validateBoard).validateUser(userId);
 		given(boardScrapRepository.findScrapBoardsWithCount(userId, pageable)).willReturn(projectionPage);
 		given(boardImageService.getBoardImageUrls(2L)).willReturn(List.of());
-		given(commentService.getCommentCount(2L)).willReturn(0);
+		given(commentService.getCommentCountMap(anyList())).willReturn(Map.of());
 
 		// when
 		ScrapBoardsRetrieveResponse result = boardScrapService.getScrapBoards(userId, pageable);

--- a/src/test/java/com/daruda/darudaserver/domain/community/service/BoardScrapServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/community/service/BoardScrapServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import com.daruda.darudaserver.domain.comment.service.CommentService;
 import com.daruda.darudaserver.domain.community.dto.response.BoardScrapResponse;
 import com.daruda.darudaserver.domain.community.entity.Board;
 import com.daruda.darudaserver.domain.community.entity.BoardScrap;
@@ -54,6 +55,12 @@ class BoardScrapServiceTest {
 
 	@Mock
 	private BoardScrapInternalService boardScrapInternalService;
+
+	@Mock
+	private BoardImageService boardImageService;
+
+	@Mock
+	private CommentService commentService;
 
 	@Test
 	@DisplayName("게시글 스크랩 토글 - 새로운 스크랩 생성 성공")
@@ -147,14 +154,18 @@ class BoardScrapServiceTest {
 		given(projection.getTitle()).willReturn("Test Title");
 		given(projection.getContent()).willReturn("Test Content");
 		given(projection.getUpdatedAt()).willReturn(LocalDateTime.now());
+		given(projection.getAuthor()).willReturn("작성자");
 		given(projection.getToolName()).willReturn("ToolName");
 		given(projection.getToolLogo()).willReturn("ToolLogo");
+		given(projection.getToolId()).willReturn(7L);
 		given(projection.getScrapCount()).willReturn(5L);
 
 		Page<ScrapBoardProjection> projectionPage = new PageImpl<>(List.of(projection), pageable, 1);
 
 		doNothing().when(validateBoard).validateUser(userId);
 		given(boardScrapRepository.findScrapBoardsWithCount(userId, pageable)).willReturn(projectionPage);
+		given(boardImageService.getBoardImageUrls(1L)).willReturn(List.of("https://image1.png"));
+		given(commentService.getCommentCount(1L)).willReturn(3);
 
 		// when
 		ScrapBoardsRetrieveResponse result = boardScrapService.getScrapBoards(userId, pageable);
@@ -164,7 +175,47 @@ class BoardScrapServiceTest {
 		assertThat(result.boardList()).hasSize(1);
 		assertThat(result.boardList().get(0).boardId()).isEqualTo(1L);
 		assertThat(result.boardList().get(0).title()).isEqualTo("Test Title");
+		assertThat(result.boardList().get(0).author()).isEqualTo("작성자");
+		assertThat(result.boardList().get(0).images()).containsExactly("https://image1.png");
+		assertThat(result.boardList().get(0).commentCount()).isEqualTo(3);
+		assertThat(result.boardList().get(0).isScraped()).isTrue();
+		assertThat(result.boardList().get(0).toolId()).isEqualTo(7L);
 		assertThat(result.boardList().get(0).scrapCount()).isEqualTo(5L);
 		assertThat(result.pageInfo().totalPages()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("즐겨찾기(스크랩) 게시글 목록 조회 - 자유 게시글은 toolName이 자유, toolId는 null")
+	void getScrapBoards_FreeBoard() {
+		// given
+		Long userId = 1L;
+		Pageable pageable = PageRequest.of(0, 10);
+
+		ScrapBoardProjection projection = mock(ScrapBoardProjection.class);
+		given(projection.getBoardId()).willReturn(2L);
+		given(projection.getTitle()).willReturn("자유 글");
+		given(projection.getContent()).willReturn("자유 내용");
+		given(projection.getUpdatedAt()).willReturn(LocalDateTime.now());
+		given(projection.getAuthor()).willReturn("자유작성자");
+		given(projection.getToolName()).willReturn(null);
+		given(projection.getToolLogo()).willReturn(null);
+		given(projection.getToolId()).willReturn(null);
+		given(projection.getScrapCount()).willReturn(0L);
+
+		Page<ScrapBoardProjection> projectionPage = new PageImpl<>(List.of(projection), pageable, 1);
+
+		doNothing().when(validateBoard).validateUser(userId);
+		given(boardScrapRepository.findScrapBoardsWithCount(userId, pageable)).willReturn(projectionPage);
+		given(boardImageService.getBoardImageUrls(2L)).willReturn(List.of());
+		given(commentService.getCommentCount(2L)).willReturn(0);
+
+		// when
+		ScrapBoardsRetrieveResponse result = boardScrapService.getScrapBoards(userId, pageable);
+
+		// then
+		assertThat(result.boardList().get(0).toolName()).isEqualTo("자유");
+		assertThat(result.boardList().get(0).toolId()).isNull();
+		assertThat(result.boardList().get(0).author()).isEqualTo("자유작성자");
+		assertThat(result.boardList().get(0).isScraped()).isTrue();
 	}
 }

--- a/src/test/java/com/daruda/darudaserver/domain/community/service/BoardServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/community/service/BoardServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import com.daruda.darudaserver.domain.comment.repository.CommentRepository;
+import com.daruda.darudaserver.domain.comment.service.CommentService;
 import com.daruda.darudaserver.domain.community.entity.Board;
 import com.daruda.darudaserver.domain.community.repository.BoardImageRepository;
 import com.daruda.darudaserver.domain.community.repository.BoardRepository;
@@ -61,6 +62,9 @@ class BoardServiceTest {
 
 	@Mock
 	private CommentRepository commentRepository;
+
+	@Mock
+	private CommentService commentService;
 
 	@Mock
 	private ValidateBoard validateBoard;
@@ -124,7 +128,7 @@ class BoardServiceTest {
 				.willReturn(new PageImpl<>(List.of(toolBoard), pageable, 1));
 			given(userRepository.findById(userId)).willReturn(Optional.of(user));
 			given(boardScrapRepository.countMapByBoardIds(List.of(10L))).willReturn(Map.of(10L, 3L));
-			given(commentRepository.countMapByBoardIds(List.of(10L))).willReturn(Map.of(10L, 3L));
+			given(commentService.getCommentCountMap(List.of(10L))).willReturn(Map.of(10L, 3L));
 			given(boardImageService.getBoardImageUrls(10L)).willReturn(List.of());
 			given(boardScrapService.isScraped(user, toolBoard)).willReturn(false);
 
@@ -155,7 +159,7 @@ class BoardServiceTest {
 				.willReturn(new PageImpl<>(List.of(freeBoard), pageable, 1));
 			given(userRepository.findById(userId)).willReturn(Optional.of(user));
 			given(boardScrapRepository.countMapByBoardIds(List.of(20L))).willReturn(Map.of());
-			given(commentRepository.countMapByBoardIds(List.of(20L))).willReturn(Map.of());
+			given(commentService.getCommentCountMap(List.of(20L))).willReturn(Map.of());
 			given(boardImageService.getBoardImageUrls(20L)).willReturn(List.of());
 			given(boardScrapService.isScraped(user, freeBoard)).willReturn(false);
 

--- a/src/test/java/com/daruda/darudaserver/domain/community/service/BoardServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/community/service/BoardServiceTest.java
@@ -124,7 +124,7 @@ class BoardServiceTest {
 				.willReturn(new PageImpl<>(List.of(toolBoard), pageable, 1));
 			given(userRepository.findById(userId)).willReturn(Optional.of(user));
 			given(boardScrapRepository.countMapByBoardIds(List.of(10L))).willReturn(Map.of(10L, 3L));
-			given(commentRepository.findCommentsByBoardId(10L)).willReturn(List.of());
+			given(commentRepository.countMapByBoardIds(List.of(10L))).willReturn(Map.of(10L, 3L));
 			given(boardImageService.getBoardImageUrls(10L)).willReturn(List.of());
 			given(boardScrapService.isScraped(user, toolBoard)).willReturn(false);
 
@@ -155,7 +155,7 @@ class BoardServiceTest {
 				.willReturn(new PageImpl<>(List.of(freeBoard), pageable, 1));
 			given(userRepository.findById(userId)).willReturn(Optional.of(user));
 			given(boardScrapRepository.countMapByBoardIds(List.of(20L))).willReturn(Map.of());
-			given(commentRepository.findCommentsByBoardId(20L)).willReturn(List.of());
+			given(commentRepository.countMapByBoardIds(List.of(20L))).willReturn(Map.of());
 			given(boardImageService.getBoardImageUrls(20L)).willReturn(List.of());
 			given(boardScrapService.isScraped(user, freeBoard)).willReturn(false);
 

--- a/src/test/java/com/daruda/darudaserver/domain/community/service/BoardServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/community/service/BoardServiceTest.java
@@ -1,18 +1,35 @@
 package com.daruda.darudaserver.domain.community.service;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import com.daruda.darudaserver.domain.comment.repository.CommentRepository;
 import com.daruda.darudaserver.domain.community.entity.Board;
 import com.daruda.darudaserver.domain.community.repository.BoardImageRepository;
+import com.daruda.darudaserver.domain.community.repository.BoardRepository;
+import com.daruda.darudaserver.domain.community.repository.BoardScrapRepository;
+import com.daruda.darudaserver.domain.community.util.ValidateBoard;
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import com.daruda.darudaserver.domain.user.dto.response.BoardListResponse;
+import com.daruda.darudaserver.domain.user.entity.User;
+import com.daruda.darudaserver.domain.user.repository.UserRepository;
 import com.daruda.darudaserver.global.image.service.ImageService;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,6 +46,24 @@ class BoardServiceTest {
 
 	@Mock
 	private BoardImageRepository boardImageRepository;
+
+	@Mock
+	private BoardRepository boardRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private BoardScrapRepository boardScrapRepository;
+
+	@Mock
+	private BoardScrapService boardScrapService;
+
+	@Mock
+	private CommentRepository commentRepository;
+
+	@Mock
+	private ValidateBoard validateBoard;
 
 	@Mock
 	private Board board;
@@ -62,5 +97,75 @@ class BoardServiceTest {
 		Mockito.verify(boardImageService).getBoardImageUrls(boardId);
 		Assertions.assertEquals(imageUrls, result);
 	}
-}
 
+	@Nested
+	@DisplayName("작성한 게시글 목록 조회")
+	class GetUserBoards {
+
+		@Test
+		@DisplayName("툴 게시글은 toolId와 scrapCount를 채워서 반환한다")
+		void getUserBoards_toolBoard_fillsToolIdAndScrapCount() {
+			// given
+			Long userId = 1L;
+			Pageable pageable = PageRequest.of(0, 5);
+			User user = mock(User.class);
+			Tool tool = mock(Tool.class);
+			Board toolBoard = mock(Board.class);
+
+			given(toolBoard.getId()).willReturn(10L);
+			given(toolBoard.getTool()).willReturn(tool);
+			given(toolBoard.getUser()).willReturn(user);
+			given(user.getNickname()).willReturn("작성자");
+			given(tool.getToolId()).willReturn(100L);
+			given(tool.getToolMainName()).willReturn("Cursor");
+			given(tool.getToolLogo()).willReturn("https://logo.png");
+
+			given(boardRepository.findAllByUserIdAndDelYnFalse(userId, pageable))
+				.willReturn(new PageImpl<>(List.of(toolBoard), pageable, 1));
+			given(userRepository.findById(userId)).willReturn(Optional.of(user));
+			given(boardScrapRepository.countMapByBoardIds(List.of(10L))).willReturn(Map.of(10L, 3L));
+			given(commentRepository.findCommentsByBoardId(10L)).willReturn(List.of());
+			given(boardImageService.getBoardImageUrls(10L)).willReturn(List.of());
+			given(boardScrapService.isScraped(user, toolBoard)).willReturn(false);
+
+			// when
+			BoardListResponse result = boardService.getUserBoards(userId, pageable);
+
+			// then
+			assertThat(result.boardList()).hasSize(1);
+			assertThat(result.boardList().get(0).getToolId()).isEqualTo(100L);
+			assertThat(result.boardList().get(0).getScrapCount()).isEqualTo(3L);
+		}
+
+		@Test
+		@DisplayName("자유 게시글은 toolId가 null, scrapCount는 0으로 반환한다")
+		void getUserBoards_freeBoard_toolIdNullAndScrapCountZero() {
+			// given
+			Long userId = 1L;
+			Pageable pageable = PageRequest.of(0, 5);
+			User user = mock(User.class);
+			Board freeBoard = mock(Board.class);
+
+			given(freeBoard.getId()).willReturn(20L);
+			given(freeBoard.getTool()).willReturn(null);
+			given(freeBoard.getUser()).willReturn(user);
+			given(user.getNickname()).willReturn("작성자");
+
+			given(boardRepository.findAllByUserIdAndDelYnFalse(userId, pageable))
+				.willReturn(new PageImpl<>(List.of(freeBoard), pageable, 1));
+			given(userRepository.findById(userId)).willReturn(Optional.of(user));
+			given(boardScrapRepository.countMapByBoardIds(List.of(20L))).willReturn(Map.of());
+			given(commentRepository.findCommentsByBoardId(20L)).willReturn(List.of());
+			given(boardImageService.getBoardImageUrls(20L)).willReturn(List.of());
+			given(boardScrapService.isScraped(user, freeBoard)).willReturn(false);
+
+			// when
+			BoardListResponse result = boardService.getUserBoards(userId, pageable);
+
+			// then
+			assertThat(result.boardList()).hasSize(1);
+			assertThat(result.boardList().get(0).getToolId()).isNull();
+			assertThat(result.boardList().get(0).getScrapCount()).isEqualTo(0L);
+		}
+	}
+}

--- a/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolBlogMetadataServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolBlogMetadataServiceTest.java
@@ -1,0 +1,96 @@
+package com.daruda.darudaserver.domain.tool.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.daruda.darudaserver.domain.tool.dto.response.ToolBlogResponse;
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import com.daruda.darudaserver.domain.tool.entity.ToolBlog;
+import com.daruda.darudaserver.domain.tool.repository.ToolBlogRepository;
+import com.daruda.darudaserver.global.scraper.OgMetadata;
+import com.daruda.darudaserver.global.scraper.OgMetadataScraper;
+
+@ExtendWith(MockitoExtension.class)
+class ToolBlogMetadataServiceTest {
+
+	@Mock
+	private ToolBlogRepository toolBlogRepository;
+
+	@Mock
+	private OgMetadataScraper ogMetadataScraper;
+
+	@InjectMocks
+	private ToolBlogMetadataService toolBlogMetadataService;
+
+	private final Tool tool = Tool.builder().toolId(10L).build();
+
+	private ToolBlog blogNeedingBackfill(final String url) {
+		return ToolBlog.builder()
+			.blogUrl(url)
+			.tool(tool)
+			.build();
+	}
+
+	@DisplayName("스크래핑에 성공하면 메타데이터를 채우고 재시도 대상에서 제외한다")
+	@Test
+	void backfillAndGet_scrapeSucceeds_appliesMetadata() {
+		// given
+		ToolBlog blog = blogNeedingBackfill("https://blog.example.com/1");
+		OgMetadata metadata = new OgMetadata("제목", "https://cdn/thumb.png", "요약", "예시 블로그", "https://ex/favicon.ico");
+		given(toolBlogRepository.findAllByTool(tool)).willReturn(List.of(blog));
+		given(ogMetadataScraper.fetch("https://blog.example.com/1")).willReturn(Optional.of(metadata));
+
+		// when
+		List<ToolBlogResponse> result = toolBlogMetadataService.backfillAndGet(tool);
+
+		// then
+		assertThat(result).singleElement()
+			.satisfies(response -> {
+				assertThat(response.title()).isEqualTo("제목");
+				assertThat(response.siteName()).isEqualTo("예시 블로그");
+			});
+		assertThat(blog.needsMetadataBackfill()).isFalse();
+	}
+
+	@DisplayName("스크래핑에 실패해도 시도 시각을 남겨 다음 조회에서 재시도하지 않는다")
+	@Test
+	void backfillAndGet_scrapeFails_stillMarksAttempted() {
+		// given
+		ToolBlog blog = blogNeedingBackfill("https://dead.example.com/1");
+		given(toolBlogRepository.findAllByTool(tool)).willReturn(List.of(blog));
+		given(ogMetadataScraper.fetch("https://dead.example.com/1")).willReturn(Optional.empty());
+
+		// when
+		List<ToolBlogResponse> result = toolBlogMetadataService.backfillAndGet(tool);
+
+		// then
+		assertThat(result).singleElement()
+			.satisfies(response -> assertThat(response.title()).isNull());
+		assertThat(blog.needsMetadataBackfill()).isFalse();
+	}
+
+	@DisplayName("이미 스크래핑을 시도한 블로그는 다시 긁지 않는다")
+	@Test
+	void backfillAndGet_alreadyAttempted_doesNotScrapeAgain() {
+		// given
+		ToolBlog attempted = ToolBlog.create("https://blog.example.com/1", tool, null);
+		given(toolBlogRepository.findAllByTool(tool)).willReturn(List.of(attempted));
+
+		// when
+		List<ToolBlogResponse> result = toolBlogMetadataService.backfillAndGet(tool);
+
+		// then
+		assertThat(result).hasSize(1);
+		then(ogMetadataScraper).shouldHaveNoInteractions();
+	}
+}

--- a/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolServiceTest.java
@@ -1,11 +1,15 @@
 package com.daruda.darudaserver.domain.tool.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.*;
 
+import java.sql.Timestamp;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,8 +17,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.daruda.darudaserver.domain.tool.dto.response.ToolLikeResponse;
+import com.daruda.darudaserver.domain.tool.dto.response.ToolListResponse;
+import com.daruda.darudaserver.domain.tool.entity.Category;
+import com.daruda.darudaserver.domain.tool.entity.License;
 import com.daruda.darudaserver.domain.tool.entity.Tool;
+import com.daruda.darudaserver.domain.tool.entity.ToolKeyword;
 import com.daruda.darudaserver.domain.tool.entity.ToolLike;
+import com.daruda.darudaserver.domain.tool.repository.ToolKeywordRepository;
 import com.daruda.darudaserver.domain.tool.repository.ToolLikeRepository;
 import com.daruda.darudaserver.domain.tool.repository.ToolRepository;
 import com.daruda.darudaserver.domain.user.entity.User;
@@ -36,6 +45,9 @@ class ToolServiceTest {
 
 	@Mock
 	private ToolLikeInternalService toolLikeInternalService;
+
+	@Mock
+	private ToolKeywordRepository toolKeywordRepository;
 
 	@InjectMocks
 	private ToolService toolService;
@@ -158,4 +170,53 @@ class ToolServiceTest {
 		assertThat(result.liked()).isFalse();
 		verify(toolLikeInternalService).saveIfAbsent(any(ToolLike.class));
 	}
+
+	@Nested
+	@DisplayName("툴 목록 조회")
+	class GetToolList {
+
+		private Tool tool(final Long toolId, final String createdAt, final License license) {
+			return Tool.builder()
+				.toolId(toolId)
+				.toolMainName("tool" + toolId)
+				.toolLogo("logo" + toolId)
+				.description("description" + toolId)
+				.license(license)
+				.category(Category.AI)
+				.createdAt(Timestamp.valueOf(createdAt))
+				.build();
+		}
+
+		@DisplayName("키워드가 없는 툴이 페이지에 포함돼도 예외 없이 전체 페이지를 반환한다")
+		@Test
+		void getToolList_toolWithoutKeywords_doesNotThrow() {
+			// given
+			Tool toolWithKeywords = tool(1L, "2024-01-03 00:00:00", License.FREE);
+			Tool toolWithoutKeywords = tool(2L, "2024-01-02 00:00:00", License.PAID);
+			Tool anotherToolWithKeywords = tool(3L, "2024-01-01 00:00:00", License.FREE);
+
+			given(toolRepository.findAll())
+				.willReturn(List.of(toolWithKeywords, toolWithoutKeywords, anotherToolWithKeywords));
+			given(toolKeywordRepository.findByTool_ToolIdIn(anyList()))
+				.willReturn(List.of(
+					ToolKeyword.builder().keywordName("문서").tool(toolWithKeywords).build(),
+					ToolKeyword.builder().keywordName("협업").tool(anotherToolWithKeywords).build()
+				));
+
+			// when
+			ToolListResponse result = toolService.getToolList(null, "createdAt", "ALL", 18, null, false);
+
+			// then
+			assertThat(result.tools()).hasSize(3);
+			assertThat(result.tools())
+				.filteredOn(toolResponse -> toolResponse.toolId().equals(2L))
+				.singleElement()
+				.satisfies(toolResponse -> assertThat(toolResponse.keywords()).isEmpty());
+			assertThat(result.tools())
+				.filteredOn(toolResponse -> toolResponse.toolId().equals(1L))
+				.singleElement()
+				.satisfies(toolResponse -> assertThat(toolResponse.keywords()).containsExactly("문서"));
+		}
+	}
+
 }

--- a/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolServiceTest.java
@@ -15,14 +15,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import com.daruda.darudaserver.domain.tool.dto.response.ToolBlogListResponse;
+import com.daruda.darudaserver.domain.tool.dto.response.ToolBlogResponse;
 import com.daruda.darudaserver.domain.tool.dto.response.ToolLikeResponse;
 import com.daruda.darudaserver.domain.tool.dto.response.ToolListResponse;
 import com.daruda.darudaserver.domain.tool.entity.Category;
 import com.daruda.darudaserver.domain.tool.entity.License;
 import com.daruda.darudaserver.domain.tool.entity.Tool;
+import com.daruda.darudaserver.domain.tool.entity.ToolBlog;
 import com.daruda.darudaserver.domain.tool.entity.ToolKeyword;
 import com.daruda.darudaserver.domain.tool.entity.ToolLike;
+import com.daruda.darudaserver.domain.tool.repository.ToolBlogRepository;
 import com.daruda.darudaserver.domain.tool.repository.ToolKeywordRepository;
 import com.daruda.darudaserver.domain.tool.repository.ToolLikeRepository;
 import com.daruda.darudaserver.domain.tool.repository.ToolRepository;
@@ -30,6 +35,7 @@ import com.daruda.darudaserver.domain.user.entity.User;
 import com.daruda.darudaserver.domain.user.repository.UserRepository;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
+import com.daruda.darudaserver.global.scraper.OgMetadata;
 
 @ExtendWith(MockitoExtension.class)
 class ToolServiceTest {
@@ -48,6 +54,12 @@ class ToolServiceTest {
 
 	@Mock
 	private ToolKeywordRepository toolKeywordRepository;
+
+	@Mock
+	private ToolBlogRepository toolBlogRepository;
+
+	@Mock
+	private ToolBlogMetadataService toolBlogMetadataService;
 
 	@InjectMocks
 	private ToolService toolService;
@@ -219,4 +231,80 @@ class ToolServiceTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("툴 블로그 조회")
+	class GetBlog {
+
+		@DisplayName("블로그가 하나도 없으면 NotFoundException 없이 빈 목록을 반환한다")
+		@Test
+		void getBlog_toolWithoutBlogs_returnsEmptyList() {
+			// given
+			Long toolId = 10L;
+			Tool tool = Tool.builder().toolId(toolId).build();
+			given(toolRepository.findById(toolId)).willReturn(Optional.of(tool));
+			given(toolBlogRepository.findAllByTool(tool)).willReturn(List.of());
+
+			// when
+			ToolBlogListResponse result = toolService.getBlog(toolId);
+
+			// then
+			assertThat(result.toolBlogs()).isEmpty();
+			then(toolBlogMetadataService).shouldHaveNoInteractions();
+		}
+
+		@DisplayName("이미 스크래핑을 시도한 블로그는 백필 빈을 호출하지 않고 필드를 그대로 반환한다")
+		@Test
+		void getBlog_blogAlreadyAttempted_returnedWithoutBackfill() {
+			// given
+			Long toolId = 10L;
+			Tool tool = Tool.builder().toolId(toolId).build();
+			OgMetadata metadata = new OgMetadata(
+				"제목", "https://cdn.example.com/thumb.png", "요약", "예시 블로그", "https://example.com/favicon.ico");
+			// create(...) 는 metadataFetchedAt 을 찍으므로 needsMetadataBackfill() == false
+			ToolBlog blog = ToolBlog.create("https://blog.example.com/1", tool, metadata);
+			ReflectionTestUtils.setField(blog, "blogId", 1L);
+			assertThat(blog.needsMetadataBackfill()).isFalse();
+			given(toolRepository.findById(toolId)).willReturn(Optional.of(tool));
+			given(toolBlogRepository.findAllByTool(tool)).willReturn(List.of(blog));
+
+			// when
+			ToolBlogListResponse result = toolService.getBlog(toolId);
+
+			// then
+			assertThat(result.toolBlogs()).hasSize(1);
+			assertThat(result.toolBlogs().get(0).blogId()).isEqualTo(1L);
+			assertThat(result.toolBlogs().get(0).title()).isEqualTo("제목");
+			assertThat(result.toolBlogs().get(0).siteName()).isEqualTo("예시 블로그");
+			assertThat(result.toolBlogs().get(0).thumbnailUrl()).isEqualTo("https://cdn.example.com/thumb.png");
+			then(toolBlogMetadataService).shouldHaveNoInteractions();
+		}
+
+		@DisplayName("스크래핑을 한 번도 시도하지 않은 블로그가 있으면 백필 빈에 위임한다")
+		@Test
+		void getBlog_blogNeverAttempted_delegatesToBackfill() {
+			// given
+			Long toolId = 10L;
+			Tool tool = Tool.builder().toolId(toolId).build();
+			ToolBlog blog = ToolBlog.builder()
+				.blogUrl("https://blog.example.com/1")
+				.tool(tool)
+				.build();
+			assertThat(blog.needsMetadataBackfill()).isTrue();
+			ToolBlogResponse backfilled = ToolBlogResponse.builder()
+				.blogId(1L)
+				.blogUrl("https://blog.example.com/1")
+				.title("긁어온 제목")
+				.build();
+			given(toolRepository.findById(toolId)).willReturn(Optional.of(tool));
+			given(toolBlogRepository.findAllByTool(tool)).willReturn(List.of(blog));
+			given(toolBlogMetadataService.backfillAndGet(tool)).willReturn(List.of(backfilled));
+
+			// when
+			ToolBlogListResponse result = toolService.getBlog(toolId);
+
+			// then
+			assertThat(result.toolBlogs()).containsExactly(backfilled);
+			then(toolBlogMetadataService).should().backfillAndGet(tool);
+		}
+	}
 }

--- a/src/test/java/com/daruda/darudaserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/user/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -31,6 +32,9 @@ import com.daruda.darudaserver.domain.community.service.BoardService;
 import com.daruda.darudaserver.domain.user.dto.request.UpdateMyRequest;
 import com.daruda.darudaserver.domain.user.dto.response.FavoriteToolsResponse;
 import com.daruda.darudaserver.domain.user.dto.response.MyProfileResponse;
+import com.daruda.darudaserver.domain.user.dto.response.PagenationDto;
+import com.daruda.darudaserver.domain.user.dto.response.ScrapBoardsResponse;
+import com.daruda.darudaserver.domain.user.dto.response.ScrapBoardsRetrieveResponse;
 import com.daruda.darudaserver.domain.user.dto.response.UpdateMyResponse;
 import com.daruda.darudaserver.domain.user.entity.User;
 import com.daruda.darudaserver.domain.user.entity.enums.Positions;
@@ -237,6 +241,15 @@ class UserControllerTest {
 		SecurityContext context = SecurityContextHolder.createEmptyContext();
 		context.setAuthentication(authentication);
 		SecurityContextHolder.setContext(context);
+		Pageable pageable = PageRequest.of(0, 5, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+		ScrapBoardsResponse item = ScrapBoardsResponse.of(1L, "Cursor", "https://logo.png", "작성자", "제목", "내용",
+			List.of("https://img1.png"), true, 10L, 5L, LocalDateTime.now(), 2);
+		ScrapBoardsRetrieveResponse response = ScrapBoardsRetrieveResponse.of(userId, List.of(item),
+			PagenationDto.of(0, 5, 1));
+
+		// when
+		when(boardScrapService.getScrapBoards(userId, pageable)).thenReturn(response);
 
 		// then
 		String token = "accessToken";
@@ -245,6 +258,11 @@ class UserControllerTest {
 				.header("Authorization", "Bearer " + token))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.status").value(SuccessCode.SUCCESS_FETCH.getHttpStatus().value()))
-			.andExpect(jsonPath("$.message").value(SuccessCode.SUCCESS_FETCH.getMessage()));
+			.andExpect(jsonPath("$.message").value(SuccessCode.SUCCESS_FETCH.getMessage()))
+			.andExpect(jsonPath("$.data.boardList[0].author").value("작성자"))
+			.andExpect(jsonPath("$.data.boardList[0].images[0]").value("https://img1.png"))
+			.andExpect(jsonPath("$.data.boardList[0].commentCount").value(2))
+			.andExpect(jsonPath("$.data.boardList[0].isScraped").value(true))
+			.andExpect(jsonPath("$.data.boardList[0].isScrapped").doesNotExist());
 	}
 }

--- a/src/test/java/com/daruda/darudaserver/global/scraper/OgMetadataScraperTest.java
+++ b/src/test/java/com/daruda/darudaserver/global/scraper/OgMetadataScraperTest.java
@@ -1,6 +1,10 @@
 package com.daruda.darudaserver.global.scraper;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import org.jsoup.Jsoup;
 import org.junit.jupiter.api.DisplayName;
@@ -104,6 +108,93 @@ class OgMetadataScraperTest {
 			// then
 			assertThat(result.thumbnailUrl()).isEqualTo("https://example.com/img/thumb.png");
 			assertThat(result.faviconUrl()).isEqualTo("https://example.com/favicon.png");
+		}
+
+		@Test
+		@DisplayName("포트가 있는 페이지 URL 이면 기본 favicon 경로에도 포트를 보존한다")
+		void parse_defaultFaviconPreservesPort() {
+			// given
+			String html = "<html><head><title>포트 있음</title></head><body></body></html>";
+
+			// when
+			OgMetadata result = scraper.parse(Jsoup.parse(html, "http://example.com:8080/post"),
+				"http://example.com:8080/post");
+
+			// then
+			assertThat(result.faviconUrl()).isEqualTo("http://example.com:8080/favicon.ico");
+		}
+	}
+
+	@Nested
+	@DisplayName("isSafePublicHttpUrl - SSRF 완화용 URL 검증")
+	class IsSafePublicHttpUrl {
+
+		@Test
+		@DisplayName("공개 IP 주소의 http URL 은 허용한다")
+		void isSafePublicHttpUrl_publicIp_true() {
+			// when & then
+			assertThat(OgMetadataScraper.isSafePublicHttpUrl("http://8.8.8.8/path")).isTrue();
+		}
+
+		@Test
+		@DisplayName("공개 도메인의 https URL 은 허용한다 (DNS 미가용 환경에서는 스킵)")
+		void isSafePublicHttpUrl_publicDomain_true() {
+			// given
+			assumeTrue(resolves("example.com"), "DNS 미가용 환경 - 스킵");
+
+			// when & then
+			assertThat(OgMetadataScraper.isSafePublicHttpUrl("https://example.com/post")).isTrue();
+		}
+
+		@Test
+		@DisplayName("localhost 호스트는 차단한다")
+		void isSafePublicHttpUrl_localhost_false() {
+			// when & then
+			assertThat(OgMetadataScraper.isSafePublicHttpUrl("http://localhost/admin")).isFalse();
+		}
+
+		@Test
+		@DisplayName("루프백 IP 는 차단한다")
+		void isSafePublicHttpUrl_loopbackIp_false() {
+			// when & then
+			assertThat(OgMetadataScraper.isSafePublicHttpUrl("https://127.0.0.1/secret")).isFalse();
+		}
+
+		@Test
+		@DisplayName("링크 로컬(메타데이터 엔드포인트) IP 는 차단한다")
+		void isSafePublicHttpUrl_linkLocalIp_false() {
+			// when & then
+			assertThat(OgMetadataScraper.isSafePublicHttpUrl("http://169.254.169.254/latest/meta-data/")).isFalse();
+		}
+
+		@Test
+		@DisplayName("사설(사이트 로컬) IP 는 차단한다")
+		void isSafePublicHttpUrl_siteLocalIp_false() {
+			// when & then
+			assertThat(OgMetadataScraper.isSafePublicHttpUrl("http://10.0.0.5/")).isFalse();
+		}
+
+		@Test
+		@DisplayName("http(s) 가 아닌 스킴은 차단한다")
+		void isSafePublicHttpUrl_nonHttpScheme_false() {
+			// when & then
+			assertThat(OgMetadataScraper.isSafePublicHttpUrl("ftp://example.com")).isFalse();
+		}
+
+		@Test
+		@DisplayName("URL 로 파싱되지 않는 문자열은 차단한다")
+		void isSafePublicHttpUrl_notAUrl_false() {
+			// when & then
+			assertThat(OgMetadataScraper.isSafePublicHttpUrl("not a url")).isFalse();
+		}
+
+		private boolean resolves(final String host) {
+			try {
+				InetAddress.getByName(host);
+				return true;
+			} catch (UnknownHostException e) {
+				return false;
+			}
 		}
 	}
 }

--- a/src/test/java/com/daruda/darudaserver/global/scraper/OgMetadataScraperTest.java
+++ b/src/test/java/com/daruda/darudaserver/global/scraper/OgMetadataScraperTest.java
@@ -1,0 +1,109 @@
+package com.daruda.darudaserver.global.scraper;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.jsoup.Jsoup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class OgMetadataScraperTest {
+
+	private static final String PAGE_URL = "https://example.com/post";
+
+	private final OgMetadataScraper scraper = new OgMetadataScraper();
+
+	private OgMetadata parse(final String html) {
+		return scraper.parse(Jsoup.parse(html, PAGE_URL), PAGE_URL);
+	}
+
+	@Nested
+	@DisplayName("parse - OG/메타 태그 파싱")
+	class Parse {
+
+		@Test
+		@DisplayName("전체 OG 태그가 있으면 모든 필드를 채운다")
+		void parse_fullOgTags() {
+			// given
+			String html = """
+				<html><head>
+				<title>fallback title</title>
+				<meta property="og:title" content="진짜 제목">
+				<meta property="og:image" content="https://cdn.example.com/thumb.png">
+				<meta property="og:description" content="요약 설명">
+				<meta property="og:site_name" content="예시 블로그">
+				<link rel="icon" href="https://example.com/assets/favicon.ico">
+				</head><body></body></html>
+				""";
+
+			// when
+			OgMetadata result = parse(html);
+
+			// then
+			assertThat(result.title()).isEqualTo("진짜 제목");
+			assertThat(result.thumbnailUrl()).isEqualTo("https://cdn.example.com/thumb.png");
+			assertThat(result.summary()).isEqualTo("요약 설명");
+			assertThat(result.siteName()).isEqualTo("예시 블로그");
+			assertThat(result.faviconUrl()).isEqualTo("https://example.com/assets/favicon.ico");
+		}
+
+		@Test
+		@DisplayName("title 태그와 meta[name=description]만 있으면 폴백으로 채운다")
+		void parse_titleAndDescriptionFallback() {
+			// given
+			String html = """
+				<html><head>
+				<title>문서 제목</title>
+				<meta name="description" content="문서 설명">
+				</head><body></body></html>
+				""";
+
+			// when
+			OgMetadata result = parse(html);
+
+			// then
+			assertThat(result.title()).isEqualTo("문서 제목");
+			assertThat(result.summary()).isEqualTo("문서 설명");
+			assertThat(result.thumbnailUrl()).isNull();
+			assertThat(result.siteName()).isEqualTo("example.com");
+			assertThat(result.faviconUrl()).isEqualTo("https://example.com/favicon.ico");
+		}
+
+		@Test
+		@DisplayName("메타 태그가 전혀 없으면 title 은 <title>, siteName 은 host, favicon 은 기본 경로로 채우고 나머지는 null")
+		void parse_noMetaAtAll() {
+			// given
+			String html = "<html><head><title>제목만 있음</title></head><body></body></html>";
+
+			// when
+			OgMetadata result = parse(html);
+
+			// then
+			assertThat(result.title()).isEqualTo("제목만 있음");
+			assertThat(result.siteName()).isEqualTo("example.com");
+			assertThat(result.faviconUrl()).isEqualTo("https://example.com/favicon.ico");
+			assertThat(result.thumbnailUrl()).isNull();
+			assertThat(result.summary()).isNull();
+		}
+
+		@Test
+		@DisplayName("상대 경로 og:image 와 상대 경로 favicon 은 절대 URL 로 변환한다")
+		void parse_relativeUrlsResolvedToAbsolute() {
+			// given
+			String html = """
+				<html><head>
+				<title>상대 경로</title>
+				<meta property="og:image" content="/img/thumb.png">
+				<link rel="shortcut icon" href="favicon.png">
+				</head><body></body></html>
+				""";
+
+			// when
+			OgMetadata result = parse(html);
+
+			// then
+			assertThat(result.thumbnailUrl()).isEqualTo("https://example.com/img/thumb.png");
+			assertThat(result.faviconUrl()).isEqualTo("https://example.com/favicon.png");
+		}
+	}
+}

--- a/src/test/java/com/daruda/darudaserver/global/scraper/OgMetadataScraperTest.java
+++ b/src/test/java/com/daruda/darudaserver/global/scraper/OgMetadataScraperTest.java
@@ -188,6 +188,14 @@ class OgMetadataScraperTest {
 			assertThat(OgMetadataScraper.isSafePublicHttpUrl("not a url")).isFalse();
 		}
 
+		@Test
+		@DisplayName("IPv6 Unique Local Address(fc00::/7) 는 차단한다")
+		void isSafePublicHttpUrl_ipv6UniqueLocal_false() {
+			// when & then
+			assertThat(OgMetadataScraper.isSafePublicHttpUrl("http://[fc00::1]/")).isFalse();
+			assertThat(OgMetadataScraper.isSafePublicHttpUrl("http://[fd00::1]/")).isFalse();
+		}
+
 		private boolean resolves(final String host) {
 			try {
 				InetAddress.getByName(host);


### PR DESCRIPTION
## 📣 Related Issue

- close #363

## 📝 Summary

목록 조회 API 4건의 응답 오류를 수정하고, 툴 블로그에 OG 메타데이터를 보강했습니다.

**1. `GET /api/v1/tool` — 키워드 없는 툴에서 404 발생 수정**
- 원인: 툴마다 `convertToKeywordRes(tool)`를 호출했고, 그 안의 `validateList`가 키워드 0건이면 `ErrorCode.DATA_NOT_FOUND`(`E404001`)를 던져 목록 전체가 404가 됨. 키워드가 하나도 없는 툴이 한 개만 섞여도 목록 API 전체가 실패.
- 수정: 페이지에 포함된 `toolId`를 모아 `getKeywordsBatch(toolIds)`로 일괄 조회하고, `keywordMap.getOrDefault(toolId, List.of())`로 키워드 없는 툴은 빈 목록 처리. N+1 쿼리도 함께 제거됨.

**2. `GET /api/v1/user/boards` — `toolId`·`scrapCount` 누락 수정**
- 원인: `getUserBoards`가 `getMyBoard`를 재사용했는데, 이 메서드는 `toolId`·`scrapCount` 없는 7-arg `BoardResponse.of`를 호출해 두 필드가 항상 null이었음.
- 수정: `getBoardList`와 동일한 방식으로 재작성. `boardScrapRepository.countMapByBoardIds`로 스크랩 수를 배치 조회(N+1 방지)하고 `toolId`를 채워 8-arg `BoardResponse.of`로 응답. 사용처가 사라진 `getMyBoard`는 제거.

**3. `GET /api/v1/user/scrap-boards` — 응답 구조를 `BoardResponse`와 통일**
- `ScrapBoardsResponse`에 `author`·`images`·`commentCount`·`toolId` 추가.
- 스크랩 여부 키를 `isScrapped` → `isScraped`로 통일 (다른 게시글 API와 표기가 달랐음).
- `ScrapBoardProjection`에 `getAuthor()`·`getToolId()` 추가, 조회 쿼리에 `JOIN b.user u`를 추가해 작성자 닉네임과 `toolId`를 함께 조회.

**4. `GET /api/v1/tool/{toolId}/blogs` — 블로그 메타데이터 보강 및 404 제거**
- `jsoup`으로 블로그 링크의 OG 메타데이터(`title`·`thumbnailUrl`·`summary`·`siteName`·`faviconUrl`)를 스크래핑하는 `OgMetadataScraper` 추가.
- `ToolBlog`에 해당 컬럼과 `metadataFetchedAt`을 추가하고, 어드민 툴 생성·수정 시점에 1회 스크래핑해 저장.
- 기존 데이터용으로 조회 시점 **1회 지연 백필**(`ToolBlogMetadataService.backfillAndGet`)을 추가. 조회 트랜잭션은 `readOnly`를 유지하기 위해 별도 트랜잭션에서 처리하며, 스크래핑에 실패해도 `metadataFetchedAt`은 기록해 재조회 시 다시 긁지 않음.
- 블로그가 0건일 때 `validateList`로 404를 던지던 동작을 제거하고 빈 목록을 반환하도록 변경.

## 🙏 Question & PR point

**1. 🚨 prod 배포 전 `ALTER TABLE` 수동 실행 필요**

prod는 `ddl-auto: validate`이고 Flyway/Liquibase 같은 마이그레이션 도구가 없습니다. **배포 전에 `docs/sql/tool_blog_og_metadata.sql`을 직접 실행해야 하며, 실행하지 않으면 애플리케이션이 기동에 실패합니다.**

```sql
ALTER TABLE tool_blog
    ADD COLUMN title              VARCHAR(500)  NULL,
    ADD COLUMN thumbnail_url      VARCHAR(2000) NULL,
    ADD COLUMN summary            VARCHAR(2000) NULL,
    ADD COLUMN site_name          VARCHAR(200)  NULL,
    ADD COLUMN favicon_url        VARCHAR(2000) NULL,
    ADD COLUMN metadata_fetched_at DATETIME     NULL;
```

**2. 🚨 breaking change — `GET /api/v1/user/scrap-boards`의 JSON 키 변경**

`isScrapped` → `isScraped`로 키 이름이 바뀝니다. **FE 동시 수정이 필요합니다.** 기존 키를 참조하던 코드는 `undefined`가 됩니다.

**3. `ScrapBoardsResponse` 구조가 `BoardResponse`와 완전히 동일해집니다**

`author`·`images`·`commentCount`가 추가되고 `toolId` 필드가 신규로 들어갑니다. 저장한 글 목록과 일반 게시글 목록을 FE에서 같은 컴포넌트로 렌더링할 수 있게 하려는 의도인데, 두 DTO를 하나로 합치는 편이 나을지 의견 부탁드립니다.

## 📬 Postman

> ⚠️ Postman 스크린샷은 리뷰 전 직접 첨부 예정입니다.

우선 로컬 전체 검증 결과를 첨부합니다. `./.claude/scripts/check-all.sh` 전 항목 통과 (editorconfig / Checkstyle / 전체 테스트).

```text
[1/4] editorconfig 자동 수정 (개행/공백/인코딩)... ✓
[2/4] editorconfig 검증...                        ✓
[3/4] Checkstyle 스타일 검증 (naver rules, 경고 0)... ✓
[4/4] 전체 테스트...                               ✓

  모든 검증 통과! PR 준비 완료.
```

전체 테스트 145건 통과 (failures 0 / errors 0 / skipped 0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 블로그 링크에서 제목, 썸네일, 요약, 사이트명, 파비콘 등 미리보기 정보를 자동으로 수집합니다.
  - 블로그 목록에 수집된 미리보기 정보가 표시됩니다.
  - 스크랩한 게시글 목록에 작성자, 이미지, 도구 정보, 스크랩 수, 댓글 수가 추가됩니다.
  - 내 게시글 목록에서 스크랩 수와 도구 정보를 확인할 수 있습니다.
  - 자유 게시판 게시글을 보다 정확하게 구분해 제공합니다.

- **개선**
  - 메타데이터 수집에 실패해도 서비스 이용이 중단되지 않습니다.
  - 키워드가 없는 도구도 목록에 정상적으로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->