### PR TITLE
#365 [Refactor] 서비스 트랜잭션 범위 컨벤션 통일

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/service/NotificationService.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -40,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class NotificationService {
 
 	// 한 시간 동안 연결
@@ -50,6 +52,7 @@ public class NotificationService {
 	private final NotificationRepository notificationRepository;
 	private final CommentRepository commentRepository;
 
+	@Transactional(propagation = Propagation.NOT_SUPPORTED)
 	public SseEmitter subscribe(Long userId, String lastEventId) {
 		String emitterId = userId + "_" + System.currentTimeMillis();
 		SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
@@ -182,7 +185,6 @@ public class NotificationService {
 		notificationEntity.markAsRead();
 	}
 
-	@Transactional
 	public List<NotificationResponse> getNotifications(Long userId) {
 		User userEntity = userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
@@ -192,7 +194,6 @@ public class NotificationService {
 			.toList();
 	}
 
-	@Transactional
 	public List<NotificationResponse> getRecentNotifications(Long userId) {
 		User userEntity = userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/daruda/darudaserver/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/service/NotificationService.java
@@ -148,6 +148,7 @@ public class NotificationService {
 		} while (users.hasNext());
 	}
 
+	@Transactional
 	public void sendBlockNotice(CommunityBlockNoticeRequest communityBlockNoticeRequest) {
 		User receiver = userRepository.findById(communityBlockNoticeRequest.userId())
 			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/daruda/darudaserver/domain/report/service/ReportService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/report/service/ReportService.java
@@ -26,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReportService {
 
 	private final UserRepository userRepository;

--- a/src/main/java/com/daruda/darudaserver/domain/user/service/AuthService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/AuthService.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthService {
 
 	private final KakaoService kakaoService;

--- a/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
@@ -3,7 +3,6 @@ package com.daruda.darudaserver.global.auth.jwt.service;
 import java.util.Arrays;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.daruda.darudaserver.domain.user.dto.response.JwtTokenResponse;
 import com.daruda.darudaserver.domain.user.repository.UserRepository;
@@ -33,7 +32,6 @@ public class TokenService {
 	private final UserRepository userRepository;
 	private final JwtTokenProvider jwtTokenProvider;
 
-	@Transactional
 	public JwtTokenResponse createToken(final Long userId, final String role) {
 		if (role == null || role.isBlank()) {
 			throw new BadRequestException(ErrorCode.INVALID_FIELD_ERROR);
@@ -49,7 +47,6 @@ public class TokenService {
 		return JwtTokenResponse.of(accessToken, refreshToken);
 	}
 
-	@Transactional
 	public JwtTokenResponse reissueToken(HttpServletRequest request) {
 		String refreshToken = getRefreshToken(request);
 
@@ -70,7 +67,6 @@ public class TokenService {
 		return createToken(userId, role);
 	}
 
-	@Transactional
 	public void deleteRefreshToken(final Long userId) {
 		Token token = tokenRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));


### PR DESCRIPTION
## 📣 Related Issue

- close #365

## 📝 Summary

`architecture` 스킬 규칙(서비스 클래스 `@Transactional(readOnly = true)` + 쓰기 메서드에만 `@Transactional`)이 누락됐던 서비스 4개를 통일했습니다. (legacy-cleanup #361 잔여분)

**`[refactor]` 트랜잭션 범위 통일**
- `NotificationService`·`AuthService`·`ReportService` — 클래스 레벨 `@Transactional(readOnly = true)` 추가, 쓰기 메서드에만 `@Transactional` 유지
- `TokenService` — `Token`이 `@RedisHash`(JPA 아님)이므로 메서드 레벨 `@Transactional` 3개 제거, 클래스 레벨 미선언
- `NotificationService.subscribe()` — SSE 장시간 연결·DB 미접근이므로 `@Transactional(propagation = NOT_SUPPORTED)` 명시
- `NotificationService.getNotifications()`·`getRecentNotifications()` — 순수 조회이므로 메서드 레벨 `@Transactional` 제거 (클래스 `readOnly` 상속)

**`[fix]` 차단 알림 발송 트랜잭션 누락**
- `NotificationService.sendBlockNotice()`에 `@Transactional` 추가. 기존에는 트랜잭션 없이 `send()` → `TransactionSynchronizationManager.registerSynchronization()`를 호출해 운영 환경에서 `IllegalStateException`이 발생하던 잠재 버그였습니다. (테스트는 `@BeforeEach`의 수동 `initSynchronization()`으로 우회 중이었음)

## 🙏 Question & PR point

- API 컨트랙트 변경 없음, 스키마 변경 없음
- `TokenService`의 `@Transactional` 제거는 Redis 저장소 동작에 영향 없음. `reissueToken`의 `userRepository.findById`는 Spring Data 기본 트랜잭션으로 처리됨
- `check-all.sh` 전체 통과 (editorconfig / Checkstyle / 전체 테스트)

## 📬 Postman

내부 리팩터링 + 트랜잭션 경계 수정으로 요청/응답 스펙 변화 없음 (해당 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 알림, 신고, 인증 및 토큰 처리의 데이터 처리 안정성과 일관성을 개선했습니다.
  * 알림 조회 작업은 읽기 전용으로 처리되며, 알림 구독과 차단 알림 전송이 각 동작에 맞는 방식으로 처리됩니다.
  * 토큰 발급·재발급 및 삭제 기능의 처리 흐름은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->