### PR TITLE
#367 [Refactor] Board·ToolScrap의 @Builder 이중 선언 제거

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/community/entity/Board.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/entity/Board.java
@@ -22,16 +22,13 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Builder
 @Table(name = "board")
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql =
 	"UPDATE board SET del_yn = true, deleted_at = NOW() "
@@ -52,7 +49,6 @@ public class Board extends BaseTimeEntity {
 	private String content;
 
 	@NotNull
-	@Builder.Default
 	private boolean delYn = false;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -63,7 +59,6 @@ public class Board extends BaseTimeEntity {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	@Builder.Default
 	private boolean isFree = true;
 
 	private Timestamp deletedAt;

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolScrap.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolScrap.java
@@ -13,17 +13,14 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "tool_scrap")
-@Builder
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ToolScrap extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,7 +35,6 @@ public class ToolScrap extends BaseTimeEntity {
 	private Tool tool;
 
 	@NotNull
-	@Builder.Default
 	private boolean delYn = false;
 
 	@Builder

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -239,10 +239,7 @@ public class ToolService {
 		ToolScrap toolScrap = toolScrapRepository.findByUserAndTool(user, tool).orElse(null);
 
 		if (toolScrap == null) {
-			toolScrap = ToolScrap.builder()
-				.user(user)
-				.tool(tool)
-				.build();
+			toolScrap = ToolScrap.of(user, tool);
 			toolScrapRepository.save(toolScrap);
 			log.debug("툴 스크랩이 생 되었습니다");
 		} else {


### PR DESCRIPTION
## 📣 Related Issue

- close #367

## 📝 Summary

CLAUDE.md 금지 항목(`@Builder`를 클래스 레벨과 생성자에 동시 선언)을 위반하던 `Board`·`ToolScrap` 엔티티를 같은 도메인의 `ToolLike` 패턴(생성자 `@Builder` + 정적 팩토리)에 맞춰 정리했습니다.

- `Board` / `ToolScrap` — 클래스 레벨 `@Builder`·`@AllArgsConstructor` 제거, 생성자 `@Builder`만 유지
- `@Builder.Default` 3개 → 필드 이니셜라이저로 대체 (기존 기본값 동작 그대로 보존)
- `ToolService.postToolScrap()` — `ToolScrap.builder()...build()` 직접 호출을 `ToolScrap.of(user, tool)` 정적 팩토리로 교체 (유일한 프로덕션 빌더 직접 호출처)

## 🙏 Question & PR point

- 동작 변경 없음. 모든 생성 경로가 `Board.create()`/`createFree()`, `ToolScrap.of()` 정적 팩토리를 사용 중이라 호출부 영향 없음
- `check-all.sh` 전체 통과 (editorconfig / Checkstyle / 전체 테스트), Lombok 경고 없음

## 📬 Postman

엔티티 생성 방식 내부 리팩터링으로 요청/응답 스펙 변화 없음 (해당 없음)