### PR TITLE
#369 [Refactor] Tool 엔티티를 BaseTimeEntity 상속으로 전환

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/admin/dto/response/AdminToolPageResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/admin/dto/response/AdminToolPageResponse.java
@@ -1,6 +1,6 @@
 package com.daruda.darudaserver.domain.admin.dto.response;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -42,7 +42,7 @@ public record AdminToolPageResponse(
 		String description,
 		Category category,
 		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
-		Timestamp createdAt
+		LocalDateTime createdAt
 	) {
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolDetailGetResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolDetailGetResponse.java
@@ -1,6 +1,6 @@
 package com.daruda.darudaserver.domain.tool.dto.response;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.daruda.darudaserver.domain.tool.entity.Tool;
@@ -25,7 +25,7 @@ public record ToolDetailGetResponse(
 	List<String> videos,
 	List<String> images,
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
-	Timestamp updatedAt,
+	LocalDateTime updatedAt,
 	Boolean isScrapped,
 	Boolean isLiked,
 	int likeCount

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
@@ -1,16 +1,10 @@
 package com.daruda.darudaserver.domain.tool.entity;
 
-import java.sql.Timestamp;
-
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import com.daruda.darudaserver.domain.admin.dto.request.CreateToolRequest;
+import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -25,12 +19,11 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "tool")
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @Builder
-public class Tool {
+public class Tool extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,12 +50,6 @@ public class Tool {
 	private String planLink;
 	@Column(name = "tool_logo", nullable = false)
 	private String toolLogo;
-	@CreatedDate
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private Timestamp createdAt;
-	@LastModifiedDate
-	@Column(name = "updated_at")
-	private Timestamp updatedAt;
 	@Column(columnDefinition = "integer default 0", nullable = false)
 	private int viewCount;
 	@Column(name = "popular", columnDefinition = "integer default 0")

--- a/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.*;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -188,15 +188,16 @@ class ToolServiceTest {
 	class GetToolList {
 
 		private Tool tool(final Long toolId, final String createdAt, final License license) {
-			return Tool.builder()
+			Tool tool = Tool.builder()
 				.toolId(toolId)
 				.toolMainName("tool" + toolId)
 				.toolLogo("logo" + toolId)
 				.description("description" + toolId)
 				.license(license)
 				.category(Category.AI)
-				.createdAt(Timestamp.valueOf(createdAt))
 				.build();
+			ReflectionTestUtils.setField(tool, "createdAt", LocalDateTime.parse(createdAt.replace(" ", "T")));
+			return tool;
 		}
 
 		@DisplayName("키워드가 없는 툴이 페이지에 포함돼도 예외 없이 전체 페이지를 반환한다")


### PR DESCRIPTION
## 📣 Related Issue

- close #369

## 📝 Summary

생성·수정 시각 관리 방식이 `Tool`만 Spring Data JPA Auditing(`@CreatedDate`/`@LastModifiedDate` + `java.sql.Timestamp`)을 쓰고 나머지 8개 엔티티는 `BaseTimeEntity`(Hibernate `@CreationTimestamp`/`@UpdateTimestamp` + `LocalDateTime`)를 쓰던 것을 통일했습니다.

- `Tool` — `extends BaseTimeEntity`, 자체 감사 필드·`@EntityListeners(AuditingEntityListener.class)`·`java.sql.Timestamp` 제거
- `ToolDetailGetResponse.updatedAt`·`AdminToolPageResponse.ToolResponse.createdAt` — `Timestamp` → `LocalDateTime` 연쇄 변경 (`@JsonFormat` 유지 → JSON 출력 `yyyy.MM.dd` 동일)
- `ToolServiceTest` — 시각 주입을 `LocalDateTime` 기준으로 변경 (별도 `[test]` 커밋)

## 🙏 Question & PR point

- API 응답 포맷 변경 없음, 스키마 변경 없음. `BaseTimeEntity.updatedAt`의 `nullable = false`는 `validate`가 검증하지 않고 `ddl-auto: update`도 기존 컬럼 제약을 바꾸지 않으며 `@UpdateTimestamp`가 항상 값을 채운다 (legacy-cleanup #361 항목 6에서 다른 8개 엔티티도 동일 처리)
- `ToolRepository` JPQL `ORDER BY t.createdAt`, `ToolService`의 `getCreatedAt().compareTo(...)`는 `LocalDateTime`에서도 정상 동작
- 이 PR 이후 `@EnableJpaAuditing`(`DarudaApplication`)과 `BaseTimeEntity`의 `@EntityListeners(AuditingEntityListener.class)`가 미사용 상태가 됨 → 후속 정리 대상
- `check-all.sh` 전체 통과

## 📬 Postman

감사 필드 타입 내부 리팩터링으로 요청/응답 스펙 변화 없음 (해당 없음)
