### PR TITLE
#371 [Refactor] report 도메인 DTO 4종 record 전환

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/report/dto/request/CreateReportRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/report/dto/request/CreateReportRequest.java
@@ -8,49 +8,31 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
+@Builder
 @Schema(description = "신고 생성 요청")
-public class CreateReportRequest {
-
+public record CreateReportRequest(
 	@Nullable
 	@Schema(description = "신고할 게시글의 ID (댓글 ID가 없을 경우 필수)", example = "1")
-	private Long boardId;
+	Long boardId,
 
 	@Nullable
 	@Schema(description = "신고할 댓글의 ID (게시글 ID가 없을 경우 필수)", example = "1")
-	private Long commentId;
+	Long commentId,
 
 	@NotNull(message = "신고 유형은 필수입니다.")
 	@Schema(description = "신고 유형", example = "SPAM", required = true)
-	private ReportType reportType;
+	ReportType reportType,
+
+	@NotNull(message = "신고 제목은 필수입니다.")
+	@Schema(description = "신고 제목", example = "광고성 게시로 인한 신고.", required = true, maxLength = 100)
+	String title,
 
 	@Nullable
 	@Size(max = 1_000, message = "신고 상세 내용은 1000자를 초과할 수 없습니다.")
 	@Schema(description = "신고 상세 내용 (선택)", example = "광고성 게시글입니다.", required = false, maxLength = 1000)
-	private String detail;
-
-	@NotNull(message = "신고 제목은 필수입니다.")
-	@Schema(description = "신고 제목", example = "광고성 게시로 인한 신고.", required = true, maxLength = 100)
-	private String title;
-
-	@Builder
-	public CreateReportRequest(
-		Long boardId,
-		Long commentId,
-		ReportType reportType,
-		String title,
-		String detail
-	) {
-		this.boardId = boardId;
-		this.commentId = commentId;
-		this.reportType = reportType;
-		this.title = title;
-		this.detail = detail;
-	}
+	String detail
+) {
 
 	public boolean isCommentReport() {
 		return commentId != null;

--- a/src/main/java/com/daruda/darudaserver/domain/report/dto/request/ProcessReportRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/report/dto/request/ProcessReportRequest.java
@@ -7,31 +7,21 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
+@Builder
 @Schema(description = "신고 처리 요청")
-public class ProcessReportRequest {
-
+public record ProcessReportRequest(
 	@NotNull(message = "처리 상태는 필수입니다.")
 	@Schema(description = "처리 상태", example = "APPROVED", required = true)
-	private ReportStatus status;
+	ReportStatus status,
 
 	@Schema(description = "제재 기간", example = "SEVEN")
-	private SuspensionDuration suspensionDuration;
+	SuspensionDuration suspensionDuration,
 
 	@Size(max = 500, message = "처리 메모는 500자를 초과할 수 없습니다.")
 	@Schema(description = "처리 메모", example = "불건전한 게시글로 인한 제재", maxLength = 500)
-	private String processNote;
-
-	@Builder
-	public ProcessReportRequest(ReportStatus status, SuspensionDuration suspensionDuration, String processNote) {
-		this.status = status;
-		this.suspensionDuration = suspensionDuration;
-		this.processNote = processNote;
-	}
+	String processNote
+) {
 
 	public Integer getSuspensionDays() {
 		return suspensionDuration != null ? suspensionDuration.getDays() : null;

--- a/src/main/java/com/daruda/darudaserver/domain/report/dto/response/CreateReportResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/report/dto/response/CreateReportResponse.java
@@ -7,75 +7,46 @@ import com.daruda.darudaserver.domain.report.entity.ReportType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
+@Builder
 @Schema(description = "신고 생성 응답")
-public class CreateReportResponse {
+public record CreateReportResponse(
 	@Schema(description = "신고 ID")
-	private final Long id;
+	Long id,
 
 	@Schema(description = "신고자 ID")
-	private final Long reporterId;
+	Long reporterId,
 
 	@Schema(description = "신고자 닉네임")
-	private final String reporterNickname;
+	String reporterNickname,
 
 	@Schema(description = "신고 대상자 ID")
-	private final Long reportedUserId;
+	Long reportedUserId,
 
 	@Schema(description = "신고 대상자 닉네임")
-	private final String reportedUserNickname;
+	String reportedUserNickname,
 
 	@Schema(description = "신고된 게시글 ID")
-	private final Long boardId;
+	Long boardId,
 
 	@Schema(description = "신고된 댓글 ID (댓글 신고인 경우)")
-	private final Long commentId;
+	Long commentId,
 
 	@Schema(description = "신고 유형")
-	private final ReportType reportType;
+	ReportType reportType,
 
 	@Schema(description = "신고 제목")
-	private final String title;
+	String title,
 
 	@Schema(description = "신고 상세 내용")
-	private final String detail;
+	String detail,
 
 	@Schema(description = "생성 일시")
-	private final LocalDateTime createdAt;
+	LocalDateTime createdAt,
 
 	@Schema(description = "수정 일시")
-	private final LocalDateTime updatedAt;
-
-	@Builder
-	private CreateReportResponse(
-		Long id,
-		Long reporterId,
-		String reporterNickname,
-		Long reportedUserId,
-		String reportedUserNickname,
-		Long boardId,
-		Long commentId,
-		ReportType reportType,
-		String title,
-		String detail,
-		LocalDateTime createdAt,
-		LocalDateTime updatedAt
-	) {
-		this.id = id;
-		this.reporterId = reporterId;
-		this.reporterNickname = reporterNickname;
-		this.reportedUserId = reportedUserId;
-		this.reportedUserNickname = reportedUserNickname;
-		this.boardId = boardId;
-		this.commentId = commentId;
-		this.reportType = reportType;
-		this.title = title;
-		this.detail = detail;
-		this.createdAt = createdAt;
-		this.updatedAt = updatedAt;
-	}
+	LocalDateTime updatedAt
+) {
 
 	public static CreateReportResponse from(Report report) {
 		return CreateReportResponse.builder()

--- a/src/main/java/com/daruda/darudaserver/domain/report/dto/response/ProcessReportResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/report/dto/response/ProcessReportResponse.java
@@ -8,51 +8,31 @@ import com.daruda.darudaserver.domain.report.entity.SuspensionDuration;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
+@Builder
 @Schema(description = "신고 처리 응답")
-public class ProcessReportResponse {
-
+public record ProcessReportResponse(
 	@Schema(description = "신고 ID", example = "1")
-	private final Long id;
+	Long id,
 
 	@Schema(description = "처리 상태", example = "APPROVED")
-	private final ReportStatus status;
+	ReportStatus status,
 
 	@Schema(description = "제재 기간(일)", example = "7")
-	private final Integer suspensionDays;
+	Integer suspensionDays,
 
 	@Schema(description = "제재 기간", example = "SEVEN")
-	private final SuspensionDuration suspensionDuration;
+	SuspensionDuration suspensionDuration,
 
 	@Schema(description = "처리자 ID", example = "1")
-	private final Long processedById;
+	Long processedById,
 
 	@Schema(description = "처리 일시")
-	private final LocalDateTime processedAt;
+	LocalDateTime processedAt,
 
 	@Schema(description = "처리 메모", example = "불건전한 게시글로 인한 제재")
-	private final String processNote;
-
-	@Builder
-	private ProcessReportResponse(
-		Long id,
-		ReportStatus status,
-		Integer suspensionDays,
-		SuspensionDuration suspensionDuration,
-		Long processedById,
-		LocalDateTime processedAt,
-		String processNote
-	) {
-		this.id = id;
-		this.status = status;
-		this.suspensionDays = suspensionDays;
-		this.suspensionDuration = suspensionDuration;
-		this.processedById = processedById;
-		this.processedAt = processedAt;
-		this.processNote = processNote;
-	}
+	String processNote
+) {
 
 	public static ProcessReportResponse from(Report report) {
 		SuspensionDuration suspensionDuration = null;

--- a/src/main/java/com/daruda/darudaserver/domain/report/service/ReportService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/report/service/ReportService.java
@@ -43,11 +43,11 @@ public class ReportService {
 		Board board = null;
 
 		if (request.isCommentReport()) {
-			if (request.getCommentId() == null) {
+			if (request.commentId() == null) {
 				throw new BusinessException(ErrorCode.INVALID_FIELD_ERROR);
 			}
 
-			comment = commentRepository.findById(request.getCommentId())
+			comment = commentRepository.findById(request.commentId())
 				.orElseThrow(() -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
 
 			board = comment.getBoard();
@@ -58,11 +58,11 @@ public class ReportService {
 				throw new BusinessException(ErrorCode.ALREADY_REPORTED);
 			}
 		} else {
-			if (request.getBoardId() == null) {
+			if (request.boardId() == null) {
 				throw new BusinessException(ErrorCode.INVALID_FIELD_ERROR);
 			}
 
-			board = boardRepository.findById(request.getBoardId())
+			board = boardRepository.findById(request.boardId())
 				.orElseThrow(() -> new BusinessException(ErrorCode.BOARD_NOT_FOUND));
 
 			reportedUser = board.getUser();
@@ -78,9 +78,9 @@ public class ReportService {
 			reportedUser,
 			board,
 			comment,
-			request.getReportType(),
-			request.getTitle(),
-			request.getDetail()
+			request.reportType(),
+			request.title(),
+			request.detail()
 		);
 
 		report = reportRepository.save(report);
@@ -106,8 +106,8 @@ public class ReportService {
 		}
 
 		// 신고 상태 변경
-		report.updateStatus(request.getStatus());
-		report.updateProcessInfo(admin.getId(), request.getProcessNote(), LocalDateTime.now());
+		report.updateStatus(request.status());
+		report.updateProcessInfo(admin.getId(), request.processNote(), LocalDateTime.now());
 		report.updateSuspensionDays(request.getSuspensionDays());
 
 		// 제재 적용

--- a/src/test/java/com/daruda/darudaserver/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/report/service/ReportServiceTest.java
@@ -133,7 +133,7 @@ class ReportServiceTest {
 			CreateReportResponse response = reportService.createReport(reporter.getId(), request);
 
 			// then
-			assertThat(response.getId()).isEqualTo(1000L);
+			assertThat(response.id()).isEqualTo(1000L);
 			then(reportRepository).should().save(any(Report.class));
 		}
 
@@ -165,7 +165,7 @@ class ReportServiceTest {
 			CreateReportResponse response = reportService.createReport(reporter.getId(), request);
 
 			// then
-			assertThat(response.getId()).isEqualTo(1000L);
+			assertThat(response.id()).isEqualTo(1000L);
 			then(reportRepository).should().save(any(Report.class));
 		}
 
@@ -330,8 +330,8 @@ class ReportServiceTest {
 			ProcessReportResponse response = reportService.processReport(admin.getId(), report.getId(), request);
 
 			// then
-			assertThat(response.getId()).isEqualTo(report.getId());
-			assertThat(response.getStatus()).isEqualTo(ReportStatus.APPROVED);
+			assertThat(response.id()).isEqualTo(report.getId());
+			assertThat(response.status()).isEqualTo(ReportStatus.APPROVED);
 		}
 
 		@Test
@@ -350,8 +350,8 @@ class ReportServiceTest {
 			ProcessReportResponse response = reportService.processReport(admin.getId(), report.getId(), request);
 
 			// then
-			assertThat(response.getId()).isEqualTo(report.getId());
-			assertThat(response.getStatus()).isEqualTo(ReportStatus.REJECTED);
+			assertThat(response.id()).isEqualTo(report.getId());
+			assertThat(response.status()).isEqualTo(ReportStatus.REJECTED);
 		}
 
 		@Test


### PR DESCRIPTION
## 📣 Related Issue

- close #371

## 📝 Summary

요청/응답 DTO는 `record` + Bean Validation이 프로젝트 필수 규칙인데 `report` 도메인 DTO 4종만 `@Getter`+`@Builder` 클래스로 남아 있어 `record`로 전환했습니다.

- `CreateReportRequest`·`ProcessReportRequest`·`CreateReportResponse`·`ProcessReportResponse` — `class` → `record`
- `@Schema`·Bean Validation 애노테이션은 record 컴포넌트로 이동, `@Builder`(테스트 호환)·`from()` 정적 팩토리·`isCommentReport()`·`getSuspensionDays()`·`@AssertTrue isValidTarget()` 유지
- `ReportService` — 접근자 호출 8곳 반영 (`request.getBoardId()` → `request.boardId()` 등)
- `ReportServiceTest` — 응답 접근자 6곳 반영 (별도 `[test]` 커밋)

## 🙏 Question & PR point

- API 요청/응답 JSON 필드 스펙 변화 없음, Swagger 스키마도 `@Schema` 유지로 동일
- report DTO는 `domain/report/` + `ReportServiceTest` 안에서만 참조 (외부 참조 없음)
- `check-all.sh` 전체 통과 (Lombok `@Builder` on record는 기존 `CreateCommentResponse` 패턴과 동일)

## 📬 Postman

DTO 내부 구조 리팩터링으로 요청/응답 스펙 변화 없음 (해당 없음)
