### PR TITLE
#373 [Refactor] BoardResponse를 record로 전환하고 of() 중복 제거

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/community/dto/response/BoardResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/dto/response/BoardResponse.java
@@ -7,115 +7,69 @@ import com.daruda.darudaserver.domain.community.entity.Board;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Builder;
-import lombok.Getter;
 
 @Builder
-@Getter
-public class BoardResponse {
-	private Long boardId;
-	private String toolName;
-	private String toolLogo;
-	private String author;
-	private String title;
-	private String content;
-	private List<String> images;
-	private Boolean isScraped;
-	private Long toolId;
-	private Long scrapCount;
+public record BoardResponse(
+	Long boardId,
+	String toolName,
+	String toolLogo,
+	String author,
+	String title,
+	String content,
+	List<String> images,
+	Boolean isScraped,
+	Long toolId,
+	Long scrapCount,
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
-	private LocalDateTime updatedAt;
-	private int commentCount;
+	LocalDateTime updatedAt,
+	int commentCount
+) {
 
 	public static BoardResponse of(final Board board, final String toolName, final String toolLogo,
 		final int commentCount, final List<String> images, final Long toolId) {
-		return createBoardRes(board, toolName, toolLogo, commentCount, images, toolId);
-	}
-
-	public static BoardResponse of(final Board board, final String toolName, final String toolLogo,
-		final int commentCount, final List<String> images, final Boolean isScraped) {
-		return getBoardRes(board, toolName, toolLogo, commentCount, images, isScraped);
-	}
-
-	public static BoardResponse of(final Board board, final String toolName, final String toolLogo,
-		final int commentCount, final List<String> images, final Boolean isScraped, final Long toolId) {
-		return getBoardResWithToolId(board, toolName, toolLogo, commentCount, images, isScraped, toolId);
-	}
-
-	public static BoardResponse of(final Board board, final String toolName, final String toolLogo,
-		final int commentCount, final List<String> images, final Boolean isScraped, final Long toolId,
-		final Long scrapCount) {
-		return getBoardResWithToolIdAndScrapCount(board, toolName, toolLogo, commentCount, images, isScraped, toolId,
-			scrapCount);
-	}
-
-	public static BoardResponse createBoardRes(final Board board, final String toolName, final String toolLogo,
-		final int commentCount, final List<String> images, final Long toolId) {
-		return BoardResponse.builder()
-			.boardId(board.getId())
-			.toolName(toolName)
-			.toolLogo(toolLogo)
-			.author(board.getUser().getNickname())
-			.title(board.getTitle())
-			.content(board.getContent())
-			.images(images)
-			.commentCount(commentCount)
-			.updatedAt(board.getUpdatedAt())
+		return baseBuilder(board, toolName, toolLogo, commentCount, images)
 			.isScraped(false)
 			.toolId(toolId)
 			.build();
 	}
 
-	public static BoardResponse getBoardRes(final Board board, final String toolName, final String toolLogo,
+	public static BoardResponse of(final Board board, final String toolName, final String toolLogo,
 		final int commentCount, final List<String> images, final Boolean isScraped) {
-		return BoardResponse.builder()
-			.boardId(board.getId())
-			.toolName(toolName)
-			.toolLogo(toolLogo)
-			.author(board.getUser().getNickname())
-			.title(board.getTitle())
-			.content(board.getContent())
-			.images(images)
-			.commentCount(commentCount)
-			.updatedAt(board.getUpdatedAt())
+		return baseBuilder(board, toolName, toolLogo, commentCount, images)
 			.isScraped(isScraped)
 			.build();
 	}
 
-	public static BoardResponse getBoardResWithToolId(final Board board, final String toolName, final String toolLogo,
+	public static BoardResponse of(final Board board, final String toolName, final String toolLogo,
 		final int commentCount, final List<String> images, final Boolean isScraped, final Long toolId) {
-		return BoardResponse.builder()
-			.boardId(board.getId())
-			.toolName(toolName)
-			.toolLogo(toolLogo)
-			.author(board.getUser().getNickname())
-			.title(board.getTitle())
-			.content(board.getContent())
-			.images(images)
-			.commentCount(commentCount)
-			.updatedAt(board.getUpdatedAt())
+		return baseBuilder(board, toolName, toolLogo, commentCount, images)
 			.isScraped(isScraped)
 			.toolId(toolId)
 			.build();
 	}
 
-	public static BoardResponse getBoardResWithToolIdAndScrapCount(final Board board, final String toolName,
-		final String toolLogo, final int commentCount, final List<String> images, final Boolean isScraped,
-		final Long toolId, final Long scrapCount) {
-		return BoardResponse.builder()
-			.boardId(board.getId())
-			.toolName(toolName)
-			.toolLogo(toolLogo)
-			.author(board.getUser().getNickname())
-			.title(board.getTitle())
-			.content(board.getContent())
-			.images(images)
-			.commentCount(commentCount)
-			.updatedAt(board.getUpdatedAt())
+	public static BoardResponse of(final Board board, final String toolName, final String toolLogo,
+		final int commentCount, final List<String> images, final Boolean isScraped, final Long toolId,
+		final Long scrapCount) {
+		return baseBuilder(board, toolName, toolLogo, commentCount, images)
 			.isScraped(isScraped)
 			.toolId(toolId)
 			.scrapCount(scrapCount)
 			.build();
 	}
 
+	private static BoardResponseBuilder baseBuilder(final Board board, final String toolName, final String toolLogo,
+		final int commentCount, final List<String> images) {
+		return BoardResponse.builder()
+			.boardId(board.getId())
+			.toolName(toolName)
+			.toolLogo(toolLogo)
+			.author(board.getUser().getNickname())
+			.title(board.getTitle())
+			.content(board.getContent())
+			.images(images)
+			.commentCount(commentCount)
+			.updatedAt(board.getUpdatedAt());
+	}
 }

--- a/src/test/java/com/daruda/darudaserver/domain/community/service/BoardServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/community/service/BoardServiceTest.java
@@ -137,8 +137,8 @@ class BoardServiceTest {
 
 			// then
 			assertThat(result.boardList()).hasSize(1);
-			assertThat(result.boardList().get(0).getToolId()).isEqualTo(100L);
-			assertThat(result.boardList().get(0).getScrapCount()).isEqualTo(3L);
+			assertThat(result.boardList().get(0).toolId()).isEqualTo(100L);
+			assertThat(result.boardList().get(0).scrapCount()).isEqualTo(3L);
 		}
 
 		@Test
@@ -168,8 +168,8 @@ class BoardServiceTest {
 
 			// then
 			assertThat(result.boardList()).hasSize(1);
-			assertThat(result.boardList().get(0).getToolId()).isNull();
-			assertThat(result.boardList().get(0).getScrapCount()).isEqualTo(0L);
+			assertThat(result.boardList().get(0).toolId()).isNull();
+			assertThat(result.boardList().get(0).scrapCount()).isEqualTo(0L);
 		}
 	}
 }


### PR DESCRIPTION
## 📣 Related Issue

- close #373

## 📝 Summary

응답 DTO는 `record`가 프로젝트 필수 규칙인데 `BoardResponse`만 `@Getter`+`@Builder` 클래스로 남아 있었고, `of()` 오버로드 4개가 거의 동일한 빌더 블록을 가진 4개의 public 헬퍼 메서드로 위임하고 있어 중복이 컸습니다. 이를 `record`로 전환하고 공통 빌더 헬퍼로 통합했습니다.

- `BoardResponse` — `class` → `record` (`@Getter` 제거, `@Builder` 유지 — `BoardService`·`BoardControllerTest` 호환)
- 4개 public 헬퍼 메서드(`createBoardRes`·`getBoardRes`·`getBoardResWithToolId`·`getBoardResWithToolIdAndScrapCount`) 제거 후, `private static baseBuilder()` 1개로 공통 필드 매핑 통합
- `of()` 4개 오버로드의 시그니처 및 `isScraped` / `toolId` / `scrapCount` 세팅 동작 그대로 보존
- `BoardServiceTest` — `getToolId()` / `getScrapCount()` 호출부를 record 접근자(`.toolId()`, `.scrapCount()`)로 변경 (별도 `[test]` 커밋)

## 🙏 Question & PR point

- API 응답 JSON 필드 스펙 변화 없음 (`@JsonFormat` 유지, `isScraped` 등 프로퍼티명 동일)
- `check-all.sh` 전체 검증 통과

## 📬 Postman

DTO 내부 구조 리팩터링으로 응답 스펙 변화 없음 (해당 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 게시글 응답 형식을 간소화하고 일관된 방식으로 생성하도록 개선했습니다.
  * 게시글 목록 정보의 접근 방식이 최신 형식에 맞게 정리되었습니다.
* **테스트**
  * 툴 게시글과 자유 게시글 목록 조회 테스트를 새로운 응답 형식에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->