### PR TITLE
#375 [Refactor] Board 엔티티의 잔여 Timestamp를 LocalDateTime으로 전환

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/community/entity/Board.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/entity/Board.java
@@ -1,6 +1,6 @@
 package com.daruda.darudaserver.domain.community.entity;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -66,7 +66,7 @@ public class Board extends BaseTimeEntity {
 	@Builder.Default
 	private boolean isFree = true;
 
-	private Timestamp deletedAt;
+	private LocalDateTime deletedAt;
 
 	@Builder
 	public Board(final String title, final String content, final Tool tool, final User user, final boolean delYn,


### PR DESCRIPTION
## 📣 Related Issue

- close #375

## 📝 Summary

프로젝트 전체에서 날짜/시간 타입으로 `LocalDateTime`을 표준으로 사용하고 있으나, `Board` 엔티티의 `deletedAt` 필드만 유일하게 `java.sql.Timestamp`로 남아 있었습니다.

- `Board.java` — `private Timestamp deletedAt` → `private LocalDateTime deletedAt` 및 `import java.sql.Timestamp` 제거
- `Comment`·`User` 엔티티와 동일한 `LocalDateTime` 타입으로 일관성 확보

## 🙏 Question & PR point

- `Board.deletedAt`은 Hibernate `@SQLDelete`의 raw SQL `NOW()`로 업데이트되며 DB 스키마/컬럼 변경 없음
- 프로젝트 내 잔여 `java.sql.Timestamp` 완전 제거
- `check-all.sh` 전체 검증 통과

## 📬 Postman

엔티티 내부 타입 리팩터링으로 해당 없음
