### PR TITLE
#377 [Refactor] 미사용 JPA Auditing 설정 및 엔티티 리스너 제거

### DIFF
--- a/src/main/java/com/daruda/darudaserver/DarudaApplication.java
+++ b/src/main/java/com/daruda/darudaserver/DarudaApplication.java
@@ -3,13 +3,11 @@ package com.daruda.darudaserver;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 import io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration;
 
-@EnableJpaAuditing
 @EnableFeignClients
 @EnableAsync
 @EnableRetry

--- a/src/main/java/com/daruda/darudaserver/global/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/daruda/darudaserver/global/common/entity/BaseTimeEntity.java
@@ -4,16 +4,13 @@ import java.time.LocalDateTime;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 
 @Getter
 @MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
 	@Column(name = "created_at", updatable = false, nullable = false)


### PR DESCRIPTION
## 📣 Related Issue

- close #377

## 📝 Summary

프로젝트의 모든 엔티티가 상속하는 `BaseTimeEntity`는 Hibernate의 `@CreationTimestamp` 및 `@UpdateTimestamp`를 사용하여 생성/수정 시간을 관리하고 있습니다. 따라서 Spring Data JPA의 `@EnableJpaAuditing` 및 `BaseTimeEntity`의 `@EntityListeners(AuditingEntityListener.class)`는 불필요한 설정(dead configuration)이므로 제거했습니다.

- `DarudaApplication.java` — `@EnableJpaAuditing` 및 import 제거
- `BaseTimeEntity.java` — `@EntityListeners(AuditingEntityListener.class)` 및 관련 import 제거

## 🙏 Question & PR point

- 시간 자동 설정은 Hibernate의 `@CreationTimestamp` / `@UpdateTimestamp`를 통해 정상 동작 보존
- `check-all.sh` 전체 검증 통과

## 📬 Postman

설정 정리 리팩터링으로 해당 없음
