### PR TITLE
#379 [Refactor] Tool 계열 및 잔여 엔티티의 PK 필드명을 id로 통일

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/admin/dto/response/AdminToolPageResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/admin/dto/response/AdminToolPageResponse.java
@@ -18,7 +18,7 @@ public record AdminToolPageResponse(
 	public static AdminToolPageResponse of(Page<Tool> toolPage) {
 		List<ToolResponse> toolResList = toolPage.getContent().stream()
 			.map(tool -> new ToolResponse(
-				tool.getToolId(),
+				tool.getId(),
 				tool.getToolLogo(),
 				tool.getToolMainName(),
 				tool.getDescription(),

--- a/src/main/java/com/daruda/darudaserver/domain/community/entity/BoardImage.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/entity/BoardImage.java
@@ -1,5 +1,6 @@
 package com.daruda.darudaserver.domain.community.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,7 +19,8 @@ import lombok.NoArgsConstructor;
 public class BoardImage {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long boardImageId;
+	@Column(name = "board_image_id")
+	private Long id;
 	private Long boardId;
 	private Long imageId;
 

--- a/src/main/java/com/daruda/darudaserver/domain/community/entity/BoardScrap.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/entity/BoardScrap.java
@@ -3,6 +3,7 @@ package com.daruda.darudaserver.domain.community.entity;
 import com.daruda.darudaserver.domain.user.entity.User;
 import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -28,7 +29,8 @@ public class BoardScrap extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long boardScrapId;
+	@Column(name = "board_scrap_id")
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "board_id", nullable = false)

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardRepository.java
@@ -46,7 +46,7 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardReposi
 	@Query(value = """
 		UPDATE board
 		SET tool_id = 0, updated_at = CURRENT_TIMESTAMP
-		WHERE tool_id = :#{#tool.toolId}
+		WHERE tool_id = :#{#tool.id}
 		""",
 		nativeQuery = true)
 	void clearTool(Tool tool);

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardRepositoryCustomImpl.java
@@ -32,7 +32,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
 			.where(
 				board.delYn.eq(false),
 				noTopic != null ? board.isFree.eq(noTopic) : null,
-				toolId != null ? board.tool.toolId.eq(toolId) : null
+				toolId != null ? board.tool.id.eq(toolId) : null
 			)
 			.fetchFirst()).orElse(0L);
 	}
@@ -55,7 +55,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
 			where.and(board.isFree.eq(noTopic));
 		}
 		if (toolId != null) {
-			where.and(board.tool.toolId.eq(toolId));
+			where.and(board.tool.id.eq(toolId));
 		}
 		if (lastScrapCount != null && lastBoardId != null) {
 			where.and(
@@ -88,7 +88,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
 			.selectFrom(board)
 			.where(
 				noTopic != null ? board.isFree.eq(noTopic) : null,
-				toolId != null ? board.tool.toolId.eq(toolId) : null,
+				toolId != null ? board.tool.id.eq(toolId) : null,
 				board.delYn.eq(Boolean.FALSE),
 				board.id.lt(cursor)
 			)

--- a/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardScrapRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/repository/BoardScrapRepository.java
@@ -38,7 +38,7 @@ public interface BoardScrapRepository extends JpaRepository<BoardScrap, Long> {
 	}
 
 	@Query(value = "SELECT b.id as boardId, b.title as title, b.content as content, b.updatedAt as updatedAt, "
-		+ "u.nickname as author, t.toolMainName as toolName, t.toolLogo as toolLogo, t.toolId as toolId, "
+		+ "u.nickname as author, t.toolMainName as toolName, t.toolLogo as toolLogo, t.id as toolId, "
 		+ "(SELECT COUNT(s) FROM BoardScrap s WHERE s.board.id = b.id) as scrapCount "
 		+ "FROM BoardScrap bs JOIN bs.board b JOIN b.user u LEFT JOIN b.tool t "
 		+ "WHERE bs.user.id = :userId AND b.delYn = false",

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -90,7 +90,7 @@ public class BoardService {
 		} else {
 			Tool tool = getToolById(boardCreateAndUpdateReq.toolId());
 			board = createToolBoard(tool, boardCreateAndUpdateReq, user);
-			toolId = tool.getToolId();
+			toolId = tool.getId();
 		}
 
 		// 이미지 처리
@@ -260,14 +260,14 @@ public class BoardService {
 				if (Boolean.FALSE.equals(noTopic) && toolId != null) {  // 툴 게시판
 					toolName = board.getTool().getToolMainName();
 					toolLogo = board.getTool().getToolLogo();
-					savedToolid = board.getTool().getToolId();
+					savedToolid = board.getTool().getId();
 				} else if (Boolean.TRUE.equals(noTopic) && toolId == null) { // 자유 게시판
 					toolName = FREE;
 					toolLogo = TOOL_LOGO;
 				} else { // 전체 게시판 (툴이 있는 경우만 가져옴)
 					toolName = (board.getTool() != null) ? board.getTool().getToolMainName() : FREE;
 					toolLogo = (board.getTool() != null) ? board.getTool().getToolLogo() : TOOL_LOGO;
-					savedToolid = (board.getTool() != null) ? board.getTool().getToolId() : null;
+					savedToolid = (board.getTool() != null) ? board.getTool().getId() : null;
 				}
 
 				int commentCount = getCommentCount(board.getId());
@@ -315,7 +315,7 @@ public class BoardService {
 		// 삭제 대상 식별 (기존에 있었지만 새로 전달받지 않은 URL)
 		List<Long> imageIdsToDelete = existingImages.stream()
 			.filter(img -> !validNewUrls.contains(img.getImageUrl()))
-			.map(com.daruda.darudaserver.global.image.entity.Image::getImageId)
+			.map(com.daruda.darudaserver.global.image.entity.Image::getId)
 			.toList();
 
 		if (!imageIdsToDelete.isEmpty()) {
@@ -394,7 +394,7 @@ public class BoardService {
 		List<BoardResponse> boardResList = content.stream()
 			.map(board -> {
 				// 자유 게시판은 tool이 없으므로 toolId는 nullable
-				Long savedToolId = board.getTool() != null ? board.getTool().getToolId() : null;
+				Long savedToolId = board.getTool() != null ? board.getTool().getId() : null;
 				String toolName = board.getTool() != null ? board.getTool().getToolMainName() : FREE;
 				String toolLogo = board.getTool() != null ? board.getTool().getToolLogo() : TOOL_LOGO;
 				int commentCount = commentCountMap.getOrDefault(board.getId(), 0L).intValue();
@@ -430,6 +430,6 @@ public class BoardService {
 
 	public Long getToolId(Long boardId) {
 		Board board = getBoardById(boardId);
-		return board.isFree() ? null : board.getTool().getToolId();
+		return board.isFree() ? null : board.getTool().getId();
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/search/document/BoardDocument.java
+++ b/src/main/java/com/daruda/darudaserver/domain/search/document/BoardDocument.java
@@ -80,7 +80,7 @@ public class BoardDocument {
 			.id(board.getId().toString())
 			.title(board.getTitle())
 			.author(board.getUser().getNickname())
-			.toolId(tool != null ? tool.getToolId() : null)
+			.toolId(tool != null ? tool.getId() : null)
 			.toolMainName(tool != null ? tool.getToolMainName() : "자유")
 			.toolSubName(tool != null ? tool.getToolSubName() : null)
 			.toolLogo(
@@ -99,7 +99,7 @@ public class BoardDocument {
 		if (tool != null) {
 			this.toolMainName = tool.getToolMainName();
 			this.toolSubName = tool.getToolSubName();
-			this.toolId = tool.getToolId();
+			this.toolId = tool.getId();
 		} else {
 			this.toolMainName = "자유";
 			this.toolSubName = null;

--- a/src/main/java/com/daruda/darudaserver/domain/search/document/ToolDocument.java
+++ b/src/main/java/com/daruda/darudaserver/domain/search/document/ToolDocument.java
@@ -69,7 +69,7 @@ public class ToolDocument {
 
 	public static ToolDocument from(Tool tool) {
 		return ToolDocument.builder()
-			.id(tool.getToolId().toString())
+			.id(tool.getId().toString())
 			.toolMainName(tool.getToolMainName())
 			.toolSubName(tool.getToolSubName())
 			.category(tool.getCategory().name())

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/PlanResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/PlanResponse.java
@@ -14,7 +14,7 @@ public record PlanResponse(
 ) {
 	public static PlanResponse of(final Plan plan) {
 		return PlanResponse.builder()
-			.planId(plan.getPlanId())
+			.planId(plan.getId())
 			.planName(plan.getPlanName())
 			.priceAnnual(plan.getPriceAnnual())
 			.priceMonthly(plan.getPriceMonthly())

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/RelatedToolResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/RelatedToolResponse.java
@@ -17,7 +17,7 @@ public record RelatedToolResponse(
 
 	public static RelatedToolResponse of(Tool tool, List<String> keywords) {
 		return RelatedToolResponse.builder()
-			.toolId(tool.getToolId())
+			.toolId(tool.getId())
 			.toolName(tool.getToolMainName())
 			.toolLogo(tool.getToolLogo())
 			.license(tool.getLicense().getKoreanName())

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolBlogResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolBlogResponse.java
@@ -16,7 +16,7 @@ public record ToolBlogResponse(
 ) {
 	public static ToolBlogResponse from(ToolBlog toolBlog) {
 		return ToolBlogResponse.builder()
-			.blogId(toolBlog.getBlogId())
+			.blogId(toolBlog.getId())
 			.blogUrl(toolBlog.getBlogUrl())
 			.title(toolBlog.getTitle())
 			.thumbnailUrl(toolBlog.getThumbnailUrl())

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolCoreResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolCoreResponse.java
@@ -12,7 +12,7 @@ public record ToolCoreResponse(
 ) {
 	public static ToolCoreResponse of(ToolCore toolCore) {
 		return ToolCoreResponse.builder()
-			.coreId(toolCore.getCoreId())
+			.coreId(toolCore.getId())
 			.coreTitle(toolCore.getCoreTitle())
 			.coreContent(toolCore.getCoreContent())
 			.build();

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolDetailGetResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolDetailGetResponse.java
@@ -34,7 +34,7 @@ public record ToolDetailGetResponse(
 		List<String> images, List<String> videos, Boolean isScrapped, Boolean isLiked, int likeCount) {
 
 		return ToolDetailGetResponse.builder()
-			.toolId(tool.getToolId())
+			.toolId(tool.getId())
 			.toolLogo(tool.getToolLogo())
 			.toolMainName(tool.upperMainName(tool.getToolMainName()))
 			.toolSubName(tool.getToolSubName())

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolDtoGetResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolDtoGetResponse.java
@@ -16,7 +16,7 @@ public record ToolDtoGetResponse(
 	// 정적 팩토리 메서드
 	public static ToolDtoGetResponse from(Tool tool, List<String> keywords, Boolean isScraped) {
 		return new ToolDtoGetResponse(
-			tool.getToolId(),
+			tool.getId(),
 			tool.upperMainName(tool.getToolMainName()),
 			tool.getToolLogo(),
 			tool.getDescription(),

--- a/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/dto/response/ToolResponse.java
@@ -18,7 +18,7 @@ public record ToolResponse(
 ) {
 	public static ToolResponse of(Tool tool, List<String> keywords, Boolean isScraped) {
 		return ToolResponse.builder()
-			.toolId(tool.getToolId())
+			.toolId(tool.getId())
 			.toolName(tool.getToolMainName())
 			.toolLogo(tool.getToolLogo())
 			.description(tool.getDescription())

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Plan.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Plan.java
@@ -27,7 +27,8 @@ public class Plan {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long planId;
+	@Column(name = "plan_id")
+	private Long id;
 
 	@Column(name = "plan_name", nullable = false)
 	private String planName;

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/RelatedTool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/RelatedTool.java
@@ -1,5 +1,6 @@
 package com.daruda.darudaserver.domain.tool.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -24,7 +25,8 @@ public class RelatedTool {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long relatedToolId;
+	@Column(name = "related_tool_id")
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "tool_id", nullable = false)

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/Tool.java
@@ -34,7 +34,8 @@ public class Tool {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long toolId;
+	@Column(name = "tool_id")
+	private Long id;
 	@Column(name = "tool_main_name", nullable = false)
 	private String toolMainName;
 	@Column(name = "tool_sub_name", nullable = false)

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolBlog.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolBlog.java
@@ -36,7 +36,7 @@ public class ToolBlog {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "tool_blog_id")
-	private Long blogId;
+	private Long id;
 
 	@Column(name = "blog_url", nullable = false, length = 50000)
 	private String blogUrl;

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolCore.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolCore.java
@@ -27,7 +27,8 @@ public class ToolCore {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long coreId;
+	@Column(name = "core_id")
+	private Long id;
 
 	@Column(name = "core_title", nullable = false)
 	private String coreTitle;

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolImage.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolImage.java
@@ -25,7 +25,7 @@ public class ToolImage {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "tool_image_id")
-	private Long imageId;
+	private Long id;
 
 	@Column(name = "image_url", nullable = false)
 	private String imageUrl;

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolKeyword.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolKeyword.java
@@ -26,7 +26,7 @@ public class ToolKeyword {
 	@Id
 	@Column(name = "keyword_id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long keywordId;
+	private Long id;
 
 	@Column(name = "keyword_name", nullable = false)
 	private String keywordName;

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolLike.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolLike.java
@@ -28,7 +28,8 @@ import lombok.NoArgsConstructor;
 public class ToolLike extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long toolLikeId;
+	@Column(name = "tool_like_id")
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
@@ -42,8 +43,8 @@ public class ToolLike extends BaseTimeEntity {
 	private boolean delYn = false;
 
 	@Builder
-	private ToolLike(final Long toolLikeId, final User user, final Tool tool) {
-		this.toolLikeId = toolLikeId;
+	private ToolLike(final Long id, final User user, final Tool tool) {
+		this.id = id;
 		this.user = user;
 		this.tool = tool;
 	}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolPlatForm.java
@@ -27,7 +27,7 @@ public class ToolPlatForm {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "platform_id")
-	private Long platformId;
+	private Long id;
 
 	@Column(name = "web", nullable = false)
 	private Boolean web;

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolScrap.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolScrap.java
@@ -3,6 +3,7 @@ package com.daruda.darudaserver.domain.tool.entity;
 import com.daruda.darudaserver.domain.user.entity.User;
 import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -27,7 +28,8 @@ import lombok.NoArgsConstructor;
 public class ToolScrap extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long toolScrapId;
+	@Column(name = "tool_scrap_id")
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
@@ -42,8 +44,8 @@ public class ToolScrap extends BaseTimeEntity {
 	private boolean delYn = false;
 
 	@Builder
-	private ToolScrap(final Long toolScrapId, final User user, final Tool tool) {
-		this.toolScrapId = toolScrapId;
+	private ToolScrap(final Long id, final User user, final Tool tool) {
+		this.id = id;
 		this.user = user;
 		this.tool = tool;
 	}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolVideo.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/ToolVideo.java
@@ -25,7 +25,7 @@ public class ToolVideo {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "tool_video_id")
-	private Long videoId;
+	private Long id;
 
 	@Column(name = "tool_video_url", nullable = false)
 	private String videoUrl;

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolKeywordRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolKeywordRepository.java
@@ -18,5 +18,5 @@ public interface ToolKeywordRepository extends JpaRepository<ToolKeyword, Long> 
 	@Transactional
 	void deleteByTool(final Tool tool);
 
-	List<ToolKeyword> findByTool_ToolIdIn(List<Long> toolIds);
+	List<ToolKeyword> findByTool_IdIn(List<Long> toolIds);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolLikeRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolLikeRepository.java
@@ -19,7 +19,7 @@ public interface ToolLikeRepository extends JpaRepository<ToolLike, Long> {
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	void deleteByUserAndTool(final User user, final Tool tool);
 
-	int countByTool_ToolId(final Long toolId);
+	int countByTool_Id(final Long toolId);
 
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	void deleteByTool(Tool tool);

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolRepository.java
@@ -15,30 +15,30 @@ import com.daruda.darudaserver.domain.tool.entity.Tool;
 public interface ToolRepository extends JpaRepository<Tool, Long> {
 
 	// 1. popular 기준 (전체 조회)
-	@Query("SELECT t FROM Tool t WHERE t.toolId < :cursor ORDER BY t.popular DESC, t.toolId DESC")
+	@Query("SELECT t FROM Tool t WHERE t.id < :cursor ORDER BY t.popular DESC, t.id DESC")
 	List<Tool> findAllWithCursorOrderByPopular(@Param("cursor") Long cursor, Pageable pageable);
 
 	// 1-2. 카테고리별 popular 조회
 	@Query("SELECT t FROM Tool t "
 		+ "WHERE t.category = :category "
-		+ "AND t.toolId < :cursor "
-		+ "ORDER BY t.popular DESC, t.toolId DESC")
+		+ "AND t.id < :cursor "
+		+ "ORDER BY t.popular DESC, t.id DESC")
 	List<Tool> findByCategoryWithCursorOrderByPopular(@Param("category") Category category,
 		@Param("cursor") Long cursor, Pageable pageable);
 
 	// 2. createdAt 기준 (전체 조회)
-	@Query("SELECT t FROM Tool t WHERE t.toolId < :cursor ORDER BY t.createdAt DESC, t.toolId DESC")
+	@Query("SELECT t FROM Tool t WHERE t.id < :cursor ORDER BY t.createdAt DESC, t.id DESC")
 	List<Tool> findAllWithCursorOrderByCreatedAt(@Param("cursor") Long cursor, Pageable pageable);
 
 	// 2-2. 카테고리별 createdAt 조회
 	@Query("SELECT t FROM Tool t "
 		+ "WHERE t.category = :category "
-		+ "AND t.toolId < :cursor "
-		+ "ORDER BY t.createdAt DESC, t.toolId DESC")
+		+ "AND t.id < :cursor "
+		+ "ORDER BY t.createdAt DESC, t.id DESC")
 	List<Tool> findByCategoryWithCursorOrderByCreatedAt(@Param("category") Category category,
 		@Param("cursor") Long cursor, Pageable pageable);
 
-	@Query("SELECT COUNT(t) FROM Tool t WHERE t.category = :category AND t.toolId < :cursor")
+	@Query("SELECT COUNT(t) FROM Tool t WHERE t.category = :category AND t.id < :cursor")
 	long countWithCursor(@Param("category") Category category, @Param("cursor") Long cursor);
 
 	long count();

--- a/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolScrapRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/repository/ToolScrapRepository.java
@@ -26,11 +26,11 @@ public interface ToolScrapRepository extends JpaRepository<ToolScrap, Long> {
 
 	Optional<ToolScrap> findByUserAndTool(final User user, final Tool tool);
 
-	@Query("SELECT COUNT(ts) FROM ToolScrap ts WHERE ts.tool.toolId = :toolId AND ts.delYn = false")
+	@Query("SELECT COUNT(ts) FROM ToolScrap ts WHERE ts.tool.id = :toolId AND ts.delYn = false")
 	int countByToolId(@Param("toolId") final Long toolId);
 
 	// toolId와 isDelYn이 false인 경우의 스크랩 수 계산
-	int countByTool_ToolIdAndDelYnFalse(final Long toolId);
+	int countByTool_IdAndDelYnFalse(final Long toolId);
 
 	boolean existsByUserAndTool(User user, Tool tool);
 
@@ -39,11 +39,11 @@ public interface ToolScrapRepository extends JpaRepository<ToolScrap, Long> {
 	void deleteByTool(Tool tool);
 
 	@Query("""
-			select ts.tool.toolId
+			select ts.tool.id
 			from ToolScrap ts
 			where ts.user.id = :userId
 			and ts.delYn = false
-			and ts.tool.toolId in :toolIds
+			and ts.tool.id in :toolIds
 		""")
 	Set<Long> findScrappedToolIds(
 		@Param("userId") Long userId,

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolLikeInternalService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolLikeInternalService.java
@@ -25,7 +25,7 @@ public class ToolLikeInternalService {
 			return true;
 		} catch (DataIntegrityViolationException e) {
 			log.warn("툴 좋아요 중복 삽입 시도 감지 (userId={}, toolId={})",
-				toolLike.getUser().getId(), toolLike.getTool().getToolId());
+				toolLike.getUser().getId(), toolLike.getTool().getId());
 			return false; // 이미 존재 → 중복으로 간주
 		}
 	}

--- a/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/service/ToolService.java
@@ -100,7 +100,7 @@ public class ToolService {
 			.map(user -> getLiked(user, tool))
 			.orElse(false);
 
-		int likeCount = toolLikeRepository.countByTool_ToolId(toolId);
+		int likeCount = toolLikeRepository.countByTool_Id(toolId);
 
 		log.debug("툴의 조회수가 증가되었습니다" + tool.getViewCount());
 		log.info("툴 세부 정보를 성공적으로 조회했습니다. toolId={}", toolId);
@@ -180,14 +180,14 @@ public class ToolService {
 			filteredTools = filteredTools.stream()
 				.sorted((t1, t2) -> {
 					int cmp = Integer.compare(t2.getPopular(), t1.getPopular());
-					return cmp != 0 ? cmp : Long.compare(t2.getToolId(), t1.getToolId());
+					return cmp != 0 ? cmp : Long.compare(t2.getId(), t1.getId());
 				})
 				.toList();
 		} else {
 			filteredTools = filteredTools.stream()
 				.sorted((t1, t2) -> {
 					int cmp = t2.getCreatedAt().compareTo(t1.getCreatedAt());
-					return cmp != 0 ? cmp : Long.compare(t2.getToolId(), t1.getToolId());
+					return cmp != 0 ? cmp : Long.compare(t2.getId(), t1.getId());
 				})
 				.toList();
 		}
@@ -198,7 +198,7 @@ public class ToolService {
 		int startIndex = 0;
 		if (lastToolId != null) {
 			Optional<Tool> lastTool = filteredTools.stream()
-				.filter(tool -> tool.getToolId().equals(lastToolId))
+				.filter(tool -> tool.getId().equals(lastToolId))
 				.findFirst();
 
 			if (lastTool.isPresent()) {
@@ -216,12 +216,12 @@ public class ToolService {
 		int lastIndex = startIndex + paginatedTools.size(); // 현재 페이지의 마지막 요소 인덱스
 
 		if (lastIndex < filteredTools.size()) {
-			nextCursor = filteredTools.get(lastIndex).getToolId(); // 다음 `toolId` 설정
+			nextCursor = filteredTools.get(lastIndex).getId(); // 다음 `toolId` 설정
 		}
 
 		//  키워드 일괄 조회 (키워드가 없는 툴은 빈 목록으로 처리)
 		List<Long> toolIds = paginatedTools.stream()
-			.map(Tool::getToolId)
+			.map(Tool::getId)
 			.toList();
 		Map<Long, List<String>> keywordMap = getKeywordsBatch(toolIds);
 
@@ -231,7 +231,7 @@ public class ToolService {
 				boolean isScraped = user != null && toolScrapRepository.findByUserAndTool(user, tool)
 					.map(toolScrap -> !toolScrap.isDelYn())
 					.orElse(false);
-				return ToolResponse.of(tool, keywordMap.getOrDefault(tool.getToolId(), List.of()), isScraped);
+				return ToolResponse.of(tool, keywordMap.getOrDefault(tool.getId(), List.of()), isScraped);
 			})
 			.toList();
 
@@ -256,7 +256,7 @@ public class ToolService {
 			log.debug("툴 스크랩이 업데이트 되었습니다");
 			toolScrap.update();
 		}
-		int scrapCount = toolScrapRepository.countByTool_ToolIdAndDelYnFalse(toolId);
+		int scrapCount = toolScrapRepository.countByTool_IdAndDelYnFalse(toolId);
 		tool.updatePopular(scrapCount);
 		return ToolScrapResponse.of(toolId, !toolScrap.isDelYn());
 	}
@@ -282,12 +282,12 @@ public class ToolService {
 				log.warn("툴 좋아요 중복 삽입 감지 (userId={}, toolId={})", userId, toolId);
 			}
 		}
-		int likeCount = toolLikeRepository.countByTool_ToolId(toolId);
+		int likeCount = toolLikeRepository.countByTool_Id(toolId);
 		return ToolLikeResponse.of(toolId, liked, likeCount);
 	}
 
 	private List<RelatedTool> relatedTool(final Tool tool) {
-		log.info("툴의 관련 툴 데이터를 조회합니다. toolId={}", tool.getToolId());
+		log.info("툴의 관련 툴 데이터를 조회합니다. toolId={}", tool.getId());
 		return relatedToolRepository.findAllByTool(tool);
 	}
 
@@ -301,7 +301,7 @@ public class ToolService {
 	}
 
 	private List<PlanResponse> getPlanByTool(final Tool tool) {
-		log.debug("툴에 연결된 플랜 정보를 조회합니다. toolId={}", tool.getToolId());
+		log.debug("툴에 연결된 플랜 정보를 조회합니다. toolId={}", tool.getId());
 		List<Plan> planList = planRepository.findAllByTool(tool);
 		validateList(planList);
 		return planList.stream()
@@ -311,7 +311,7 @@ public class ToolService {
 	}
 
 	private List<ToolBlogResponse> getBlogByTool(final Tool tool) {
-		log.debug("툴에 연결된 블로그 정보를 조회합니다. toolId={}", tool.getToolId());
+		log.debug("툴에 연결된 블로그 정보를 조회합니다. toolId={}", tool.getId());
 		List<ToolBlog> blogList = toolBlogRepository.findAllByTool(tool);
 		// 블로그가 없으면 빈 목록을 반환한다(404 아님).
 		boolean needsBackfill = blogList.stream().anyMatch(ToolBlog::needsMetadataBackfill);
@@ -325,7 +325,7 @@ public class ToolService {
 	}
 
 	private List<ToolCoreResponse> getToolCoreByTool(final Tool tool) {
-		log.debug("툴에 연결된 핵심 정보를 조회합니다. toolId={}", tool.getToolId());
+		log.debug("툴에 연결된 핵심 정보를 조회합니다. toolId={}", tool.getId());
 		List<ToolCore> toolCoreList = toolCoreRepository.findAllByTool(tool);
 		validateList(toolCoreList);
 		return toolCoreList.stream()
@@ -404,11 +404,11 @@ public class ToolService {
 		}
 
 		List<ToolKeyword> keywords =
-			toolKeywordRepository.findByTool_ToolIdIn(toolIds);
+			toolKeywordRepository.findByTool_IdIn(toolIds);
 
 		return keywords.stream()
 			.collect(Collectors.groupingBy(
-				k -> k.getTool().getToolId(),
+				k -> k.getTool().getId(),
 				Collectors.mapping(
 					ToolKeyword::getKeywordName,
 					Collectors.toList()

--- a/src/main/java/com/daruda/darudaserver/global/image/entity/Image.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/entity/Image.java
@@ -16,14 +16,15 @@ public class Image {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long imageId;
+	@Column(name = "image_id")
+	private Long id;
 
 	@Column(name = "image_url", nullable = false, length = 500)
 	private String imageUrl;
 
 	@Builder
-	public Image(final Long imageId, final String imageUrl) {
-		this.imageId = imageId;
+	public Image(final Long id, final String imageUrl) {
+		this.id = id;
 		this.imageUrl = imageUrl;
 	}
 

--- a/src/main/java/com/daruda/darudaserver/global/image/service/ImageService.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/service/ImageService.java
@@ -73,7 +73,7 @@ public class ImageService {
 			.toList();
 
 		return imageRepository.saveAll(images).stream()
-			.map(Image::getImageId)
+			.map(Image::getId)
 			.toList();
 	}
 

--- a/src/test/java/com/daruda/darudaserver/domain/community/service/BoardServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/community/service/BoardServiceTest.java
@@ -120,7 +120,7 @@ class BoardServiceTest {
 			given(toolBoard.getTool()).willReturn(tool);
 			given(toolBoard.getUser()).willReturn(user);
 			given(user.getNickname()).willReturn("작성자");
-			given(tool.getToolId()).willReturn(100L);
+			given(tool.getId()).willReturn(100L);
 			given(tool.getToolMainName()).willReturn("Cursor");
 			given(tool.getToolLogo()).willReturn("https://logo.png");
 

--- a/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolBlogMetadataServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolBlogMetadataServiceTest.java
@@ -32,7 +32,7 @@ class ToolBlogMetadataServiceTest {
 	@InjectMocks
 	private ToolBlogMetadataService toolBlogMetadataService;
 
-	private final Tool tool = Tool.builder().toolId(10L).build();
+	private final Tool tool = Tool.builder().id(10L).build();
 
 	private ToolBlog blogNeedingBackfill(final String url) {
 		return ToolBlog.builder()

--- a/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/tool/service/ToolServiceTest.java
@@ -110,13 +110,13 @@ class ToolServiceTest {
 			.nickname("tester")
 			.positions(null)
 			.build();
-		Tool tool = Tool.builder().toolId(toolId).build();
+		Tool tool = Tool.builder().id(toolId).build();
 
 		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 		when(toolRepository.findById(toolId)).thenReturn(Optional.of(tool));
 		when(toolLikeRepository.existsByUserAndTool(user, tool)).thenReturn(false);
 		when(toolLikeInternalService.saveIfAbsent(any(ToolLike.class))).thenReturn(true);
-		when(toolLikeRepository.countByTool_ToolId(toolId)).thenReturn(1);
+		when(toolLikeRepository.countByTool_Id(toolId)).thenReturn(1);
 
 		// when
 		ToolLikeResponse result = toolService.postToolLike(userId, toolId);
@@ -139,12 +139,12 @@ class ToolServiceTest {
 			.nickname("tester")
 			.positions(null)
 			.build();
-		Tool tool = Tool.builder().toolId(toolId).build();
+		Tool tool = Tool.builder().id(toolId).build();
 
 		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 		when(toolRepository.findById(toolId)).thenReturn(Optional.of(tool));
 		when(toolLikeRepository.existsByUserAndTool(user, tool)).thenReturn(true);
-		when(toolLikeRepository.countByTool_ToolId(toolId)).thenReturn(0);
+		when(toolLikeRepository.countByTool_Id(toolId)).thenReturn(0);
 
 		// when
 		ToolLikeResponse result = toolService.postToolLike(userId, toolId);
@@ -167,13 +167,13 @@ class ToolServiceTest {
 			.nickname("tester")
 			.positions(null)
 			.build();
-		Tool tool = Tool.builder().toolId(toolId).build();
+		Tool tool = Tool.builder().id(toolId).build();
 
 		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 		when(toolRepository.findById(toolId)).thenReturn(Optional.of(tool));
 		when(toolLikeRepository.existsByUserAndTool(user, tool)).thenReturn(false);
 		when(toolLikeInternalService.saveIfAbsent(any(ToolLike.class))).thenReturn(false);
-		when(toolLikeRepository.countByTool_ToolId(toolId)).thenReturn(1);
+		when(toolLikeRepository.countByTool_Id(toolId)).thenReturn(1);
 
 		// when
 		ToolLikeResponse result = toolService.postToolLike(userId, toolId);
@@ -189,7 +189,7 @@ class ToolServiceTest {
 
 		private Tool tool(final Long toolId, final String createdAt, final License license) {
 			return Tool.builder()
-				.toolId(toolId)
+				.id(toolId)
 				.toolMainName("tool" + toolId)
 				.toolLogo("logo" + toolId)
 				.description("description" + toolId)
@@ -209,7 +209,7 @@ class ToolServiceTest {
 
 			given(toolRepository.findAll())
 				.willReturn(List.of(toolWithKeywords, toolWithoutKeywords, anotherToolWithKeywords));
-			given(toolKeywordRepository.findByTool_ToolIdIn(anyList()))
+			given(toolKeywordRepository.findByTool_IdIn(anyList()))
 				.willReturn(List.of(
 					ToolKeyword.builder().keywordName("문서").tool(toolWithKeywords).build(),
 					ToolKeyword.builder().keywordName("협업").tool(anotherToolWithKeywords).build()
@@ -240,7 +240,7 @@ class ToolServiceTest {
 		void getBlog_toolWithoutBlogs_returnsEmptyList() {
 			// given
 			Long toolId = 10L;
-			Tool tool = Tool.builder().toolId(toolId).build();
+			Tool tool = Tool.builder().id(toolId).build();
 			given(toolRepository.findById(toolId)).willReturn(Optional.of(tool));
 			given(toolBlogRepository.findAllByTool(tool)).willReturn(List.of());
 
@@ -257,12 +257,12 @@ class ToolServiceTest {
 		void getBlog_blogAlreadyAttempted_returnedWithoutBackfill() {
 			// given
 			Long toolId = 10L;
-			Tool tool = Tool.builder().toolId(toolId).build();
+			Tool tool = Tool.builder().id(toolId).build();
 			OgMetadata metadata = new OgMetadata(
 				"제목", "https://cdn.example.com/thumb.png", "요약", "예시 블로그", "https://example.com/favicon.ico");
 			// create(...) 는 metadataFetchedAt 을 찍으므로 needsMetadataBackfill() == false
 			ToolBlog blog = ToolBlog.create("https://blog.example.com/1", tool, metadata);
-			ReflectionTestUtils.setField(blog, "blogId", 1L);
+			ReflectionTestUtils.setField(blog, "id", 1L);
 			assertThat(blog.needsMetadataBackfill()).isFalse();
 			given(toolRepository.findById(toolId)).willReturn(Optional.of(tool));
 			given(toolBlogRepository.findAllByTool(tool)).willReturn(List.of(blog));
@@ -284,7 +284,7 @@ class ToolServiceTest {
 		void getBlog_blogNeverAttempted_delegatesToBackfill() {
 			// given
 			Long toolId = 10L;
-			Tool tool = Tool.builder().toolId(toolId).build();
+			Tool tool = Tool.builder().id(toolId).build();
 			ToolBlog blog = ToolBlog.builder()
 				.blogUrl("https://blog.example.com/1")
 				.tool(tool)


### PR DESCRIPTION
## 📣 Related Issue

- close #379

## 📝 Summary

`User`, `Board`, `Comment`, `Notification`, `Report` 등 대부분의 도메인 엔티티는 PK 필드명으로 `id`를 사용하고 있었으나, `Tool` 도메인 및 일부 엔티티는 `toolId`, `planId` 등 `{entity}Id` 형태의 PK 필드명을 유지하고 있어 일관성이 맞지 않았습니다. 이를 `id`로 통일했습니다.

- 14개 엔티티 PK 필드명 `id` 통일 (`@Column(name = "...")` DB 컬럼 매핑 보존)
  - `BoardImage`, `BoardScrap`, `Image`, `Tool`, `ToolScrap`, `ToolLike`, `ToolCore`, `ToolImage`, `ToolKeyword`, `ToolVideo`, `ToolBlog`, `ToolPlatForm`, `Plan`, `RelatedTool`
- 관련 Repository 쿼리(`@Query` JPQL/네이티브), Spring Data JPA 파생 쿼리 메서드(`countByTool_Id`, `findByTool_IdIn` 등), QueryDSL (`board.tool.id`) 수정
- 서비스, DTO, Search Document, 내부 컴포넌트의 엔티티 getter 호출부(`tool.getToolId()` → `tool.getId()` 등) 수정
- 테스트 코드의 builder/mocking/접근자 수정 (별도 `[test]` 커밋)

## 🙏 Question & PR point

- DB 컬럼명(`tool_id`, `plan_id` 등)은 그대로 유지되므로 DB 스키마/테이블 변경 없음
- API 응답 DTO 필드명은 변경하지 않고 내부 엔티티 PK 필드명 및 게터만 리팩터링
- `check-all.sh` 전체 검증 통과

## 📬 Postman

엔티티 내부 구조 리팩터링으로 응답 스펙 변화 없음 (해당 없음)
