### PR TITLE
#382 [Refactor] 비즈니스 예외 처리를 ErrorCode ENUM 서브클래스 계층으로 전면 통일

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/admin/service/AdminService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/admin/service/AdminService.java
@@ -179,7 +179,7 @@ public class AdminService {
 	@Transactional
 	public void updateTool(final Long toolId, final UpdateToolRequest req) {
 		Tool tool = toolRepository.findById(toolId)
-			.orElseThrow(() -> new IllegalArgumentException("Tool not found: " + toolId));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.TOOL_NOT_FOUND));
 
 		// 툴 정보 수정
 		tool.update(

--- a/src/main/java/com/daruda/darudaserver/domain/notification/entity/enums/BlockDurationInDay.java
+++ b/src/main/java/com/daruda/darudaserver/domain/notification/entity/enums/BlockDurationInDay.java
@@ -1,7 +1,7 @@
 package com.daruda.darudaserver.domain.notification.entity.enums;
 
 import com.daruda.darudaserver.global.error.code.ErrorCode;
-import com.daruda.darudaserver.global.error.exception.BusinessException;
+import com.daruda.darudaserver.global.error.exception.InvalidValueException;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +25,6 @@ public enum BlockDurationInDay {
 				return blockDurationInDay;
 			}
 		}
-		throw new BusinessException(ErrorCode.INVALID_FIELD_ERROR);
+		throw new InvalidValueException(ErrorCode.INVALID_FIELD_ERROR);
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/report/entity/SuspensionDuration.java
+++ b/src/main/java/com/daruda/darudaserver/domain/report/entity/SuspensionDuration.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.daruda.darudaserver.global.error.code.ErrorCode;
-import com.daruda.darudaserver.global.error.exception.BusinessException;
+import com.daruda.darudaserver.global.error.exception.InvalidValueException;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +29,7 @@ public enum SuspensionDuration {
 	public static SuspensionDuration fromString(String description) {
 		SuspensionDuration duration = DESCRIPTION_MAP.get(description);
 		if (duration == null) {
-			throw new BusinessException(ErrorCode.INVALID_FIELD_ERROR);
+			throw new InvalidValueException(ErrorCode.INVALID_FIELD_ERROR);
 		}
 
 		return duration;

--- a/src/main/java/com/daruda/darudaserver/domain/report/service/ReportService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/report/service/ReportService.java
@@ -19,8 +19,10 @@ import com.daruda.darudaserver.domain.user.entity.User;
 import com.daruda.darudaserver.domain.user.entity.enums.Positions;
 import com.daruda.darudaserver.domain.user.repository.UserRepository;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
-import com.daruda.darudaserver.global.error.exception.BusinessException;
+import com.daruda.darudaserver.global.error.exception.BadRequestException;
 import com.daruda.darudaserver.global.error.exception.ForbiddenException;
+import com.daruda.darudaserver.global.error.exception.InvalidValueException;
+import com.daruda.darudaserver.global.error.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -37,39 +39,39 @@ public class ReportService {
 	public CreateReportResponse createReport(Long reporterId, CreateReportRequest request) {
 		User reportedUser;
 		User reporter = userRepository.findById(reporterId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
 		Comment comment = null;
 		Board board = null;
 
 		if (request.isCommentReport()) {
 			if (request.getCommentId() == null) {
-				throw new BusinessException(ErrorCode.INVALID_FIELD_ERROR);
+				throw new InvalidValueException(ErrorCode.INVALID_FIELD_ERROR);
 			}
 
 			comment = commentRepository.findById(request.getCommentId())
-				.orElseThrow(() -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
+				.orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
 
 			board = comment.getBoard();
 			reportedUser = comment.getUser();
 
 			// 중복 신고 검증
 			if (reportRepository.existsByReporterAndComment(reporter, comment)) {
-				throw new BusinessException(ErrorCode.ALREADY_REPORTED);
+				throw new BadRequestException(ErrorCode.ALREADY_REPORTED);
 			}
 		} else {
 			if (request.getBoardId() == null) {
-				throw new BusinessException(ErrorCode.INVALID_FIELD_ERROR);
+				throw new InvalidValueException(ErrorCode.INVALID_FIELD_ERROR);
 			}
 
 			board = boardRepository.findById(request.getBoardId())
-				.orElseThrow(() -> new BusinessException(ErrorCode.BOARD_NOT_FOUND));
+				.orElseThrow(() -> new NotFoundException(ErrorCode.BOARD_NOT_FOUND));
 
 			reportedUser = board.getUser();
 
 			// 중복 신고 검증
 			if (reportRepository.existsByReporterAndBoard(reporter, board)) {
-				throw new BusinessException(ErrorCode.ALREADY_REPORTED);
+				throw new BadRequestException(ErrorCode.ALREADY_REPORTED);
 			}
 		}
 
@@ -90,7 +92,7 @@ public class ReportService {
 	@Transactional
 	public ProcessReportResponse processReport(Long adminId, Long reportId, ProcessReportRequest request) {
 		User admin = userRepository.findById(adminId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
 		// 관리자 권한 검증
 		if (admin.getPositions() != Positions.ADMIN) {
@@ -98,11 +100,11 @@ public class ReportService {
 		}
 
 		Report report = reportRepository.findById(reportId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.REPORT_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.REPORT_NOT_FOUND));
 
 		// 이미 처리된 신고인지 확인
 		if (!report.isPending()) {
-			throw new BusinessException(ErrorCode.ALREADY_PROCESSED_REPORT);
+			throw new BadRequestException(ErrorCode.ALREADY_PROCESSED_REPORT);
 		}
 
 		// 신고 상태 변경

--- a/src/main/java/com/daruda/darudaserver/domain/tool/entity/PlanType.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/entity/PlanType.java
@@ -1,5 +1,8 @@
 package com.daruda.darudaserver.domain.tool.entity;
 
+import com.daruda.darudaserver.global.error.code.ErrorCode;
+import com.daruda.darudaserver.global.error.exception.NotFoundException;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +22,6 @@ public enum PlanType {
 				return planType;
 			}
 		}
-		throw new IllegalArgumentException("Invalid PlanType: " + type);
+		throw new NotFoundException(ErrorCode.DATA_NOT_FOUND);
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/user/entity/enums/Positions.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/entity/enums/Positions.java
@@ -1,7 +1,7 @@
 package com.daruda.darudaserver.domain.user.entity.enums;
 
 import com.daruda.darudaserver.global.error.code.ErrorCode;
-import com.daruda.darudaserver.global.error.exception.BusinessException;
+import com.daruda.darudaserver.global.error.exception.InvalidValueException;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +23,7 @@ public enum Positions {
 				return position;
 			}
 		}
-		throw new BusinessException(ErrorCode.INVALID_FIELD_ERROR);
+		throw new InvalidValueException(ErrorCode.INVALID_FIELD_ERROR);
 	}
 
 	public static Positions fromEngName(String engName) {
@@ -32,6 +32,6 @@ public enum Positions {
 				return position;
 			}
 		}
-		throw new BusinessException(ErrorCode.INVALID_FIELD_ERROR);
+		throw new InvalidValueException(ErrorCode.INVALID_FIELD_ERROR);
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/user/service/AuthService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/AuthService.java
@@ -23,7 +23,8 @@ import com.daruda.darudaserver.domain.user.entity.enums.SocialType;
 import com.daruda.darudaserver.domain.user.repository.UserRepository;
 import com.daruda.darudaserver.global.auth.jwt.service.TokenService;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
-import com.daruda.darudaserver.global.error.exception.BusinessException;
+import com.daruda.darudaserver.global.error.exception.ConflictException;
+import com.daruda.darudaserver.global.error.exception.InvalidValueException;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -47,14 +48,14 @@ public class AuthService {
 	@Transactional
 	public SignUpSuccessResponse register(final String email, final String nickname, final String positionStr) {
 		if (userRepository.existsByEmail(email)) {
-			throw new BusinessException(ErrorCode.DUPLICATED_EMAIL);
+			throw new ConflictException(ErrorCode.DUPLICATED_EMAIL);
 		}
 
 		Positions positions = Positions.fromString(positionStr);
 
 		// 관리자로 회원 가입 불가
 		if (Positions.ADMIN.equals(positions)) {
-			throw new BusinessException(ErrorCode.INVALID_FIELD_ERROR);
+			throw new InvalidValueException(ErrorCode.INVALID_FIELD_ERROR);
 		}
 
 		User userEntity = User.of(email, nickname, positions);

--- a/src/main/java/com/daruda/darudaserver/domain/user/service/KakaoService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/KakaoService.java
@@ -10,6 +10,7 @@ import com.daruda.darudaserver.global.auth.client.KakaoAPiFeignClient;
 import com.daruda.darudaserver.global.auth.client.KakaoFeignClient;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.BusinessException;
+import com.daruda.darudaserver.global.error.exception.UnauthorizedException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -65,7 +66,7 @@ public class KakaoService implements SocialService {
 			return kakaoTokenResponse.accessToken();
 		} catch (Exception e) {
 			log.error("Error on: ", e);
-			throw new BusinessException(ErrorCode.AUTHENTICATION_CODE_EXPIRED);
+			throw new UnauthorizedException(ErrorCode.AUTHENTICATION_CODE_EXPIRED);
 		}
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
@@ -17,7 +17,8 @@ import com.daruda.darudaserver.domain.user.entity.User;
 import com.daruda.darudaserver.domain.user.entity.enums.Positions;
 import com.daruda.darudaserver.domain.user.repository.UserRepository;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
-import com.daruda.darudaserver.global.error.exception.BusinessException;
+import com.daruda.darudaserver.global.error.exception.BadRequestException;
+import com.daruda.darudaserver.global.error.exception.ConflictException;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,6 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 @Slf4j
 public class UserService {
-
 	private final UserRepository userRepository;
 	private final ToolScrapRepository toolScrapRepository;
 	private final ToolService toolService;
@@ -45,7 +45,7 @@ public class UserService {
 
 	public FavoriteToolsResponse getFavoriteTools(Long userId) {
 		User userEntity = userRepository.findById(userId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
 		List<ToolScrap> toolScrapList = toolScrapRepository.findAllByUserId(userId);
 		List<Tool> tools = toolScrapList.stream()
@@ -68,7 +68,7 @@ public class UserService {
 	@Transactional
 	public UpdateMyResponse updateProfile(Long userId, String nickname, String positionStr) {
 		if (positionStr == null && nickname == null) {
-			throw new BusinessException(ErrorCode.MISSING_PARAMETER);
+			throw new BadRequestException(ErrorCode.MISSING_PARAMETER);
 		}
 
 		User userEntity = userRepository.findById(userId)
@@ -83,7 +83,7 @@ public class UserService {
 		}
 
 		if (isDuplicatedNickname(nickname)) {
-			throw new BusinessException(ErrorCode.DUPLICATED_NICKNAME);
+			throw new ConflictException(ErrorCode.DUPLICATED_NICKNAME);
 		}
 
 		if (positions == null) {

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/UserAuthentication.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/UserAuthentication.java
@@ -8,6 +8,9 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import com.daruda.darudaserver.global.error.code.ErrorCode;
+import com.daruda.darudaserver.global.error.exception.UnauthorizedException;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -20,7 +23,7 @@ public class UserAuthentication extends UsernamePasswordAuthenticationToken {
 	public static UserAuthentication createUserAuthentication(Long userId, String role) {
 		log.debug("createUserAuthentication - userId: {} role: {}", userId, role);
 		if (role == null || role.isBlank()) {
-			throw new IllegalArgumentException("role must not be null/blank");
+			throw new UnauthorizedException(ErrorCode.EMPTY_OR_INVALID_TOKEN);
 		}
 		String normalized = role.startsWith("ROLE_") ? role.substring(5) : role;
 		SimpleGrantedAuthority authority =

--- a/src/main/java/com/daruda/darudaserver/global/error/exception/ConflictException.java
+++ b/src/main/java/com/daruda/darudaserver/global/error/exception/ConflictException.java
@@ -1,0 +1,9 @@
+package com.daruda.darudaserver.global.error.exception;
+
+import com.daruda.darudaserver.global.error.code.ErrorCode;
+
+public class ConflictException extends BusinessException {
+	public ConflictException(final ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/daruda/darudaserver/global/image/service/ImageService.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/service/ImageService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.daruda.darudaserver.global.error.code.ErrorCode;
-import com.daruda.darudaserver.global.error.exception.BusinessException;
+import com.daruda.darudaserver.global.error.exception.InvalidValueException;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
 import com.daruda.darudaserver.global.image.dto.response.PresignedUrlResponse;
 import com.daruda.darudaserver.global.image.entity.Image;
@@ -79,18 +79,18 @@ public class ImageService {
 
 	private void validateExtensionString(String extension) {
 		if (extension == null || !ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
-			throw new BusinessException(ErrorCode.INVALID_IMAGE_TYPE);
+			throw new InvalidValueException(ErrorCode.INVALID_IMAGE_TYPE);
 		}
 	}
 
 	private void validateUrlExtension(String url) {
 		if (url == null) {
-			throw new BusinessException(ErrorCode.INVALID_IMAGE_TYPE);
+			throw new InvalidValueException(ErrorCode.INVALID_IMAGE_TYPE);
 		}
 		String lowerUrl = url.toLowerCase();
 		boolean isValid = ALLOWED_EXTENSIONS.stream().anyMatch(lowerUrl::endsWith);
 		if (!isValid) {
-			throw new BusinessException(ErrorCode.INVALID_IMAGE_TYPE);
+			throw new InvalidValueException(ErrorCode.INVALID_IMAGE_TYPE);
 		}
 	}
 }

--- a/src/test/java/com/daruda/darudaserver/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/report/service/ReportServiceTest.java
@@ -35,8 +35,11 @@ import com.daruda.darudaserver.domain.user.entity.User;
 import com.daruda.darudaserver.domain.user.entity.enums.Positions;
 import com.daruda.darudaserver.domain.user.repository.UserRepository;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
+import com.daruda.darudaserver.global.error.exception.BadRequestException;
 import com.daruda.darudaserver.global.error.exception.BusinessException;
 import com.daruda.darudaserver.global.error.exception.ForbiddenException;
+import com.daruda.darudaserver.global.error.exception.InvalidValueException;
+import com.daruda.darudaserver.global.error.exception.NotFoundException;
 
 @ExtendWith(MockitoExtension.class)
 class ReportServiceTest {
@@ -184,12 +187,12 @@ class ReportServiceTest {
 
 			// when & then
 			assertThatThrownBy(() -> reportService.createReport(99L, request))
-				.isInstanceOf(BusinessException.class)
+				.isInstanceOf(NotFoundException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
 		}
 
 		@Test
-		@DisplayName("게시글이 존재하지 않으면 BusinessException")
+		@DisplayName("게시글이 존재하지 않으면 NotFoundException")
 		void createReport_board_not_found() {
 			// given
 			given(userRepository.findById(reporter.getId())).willReturn(Optional.of(reporter));
@@ -204,12 +207,12 @@ class ReportServiceTest {
 
 			// when & then
 			assertThatThrownBy(() -> reportService.createReport(reporter.getId(), request))
-				.isInstanceOf(BusinessException.class)
+				.isInstanceOf(NotFoundException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.BOARD_NOT_FOUND);
 		}
 
 		@Test
-		@DisplayName("댓글이 존재하지 않으면 BusinessException")
+		@DisplayName("댓글이 존재하지 않으면 NotFoundException")
 		void createReport_comment_not_found() {
 			// given
 			given(userRepository.findById(reporter.getId())).willReturn(Optional.of(reporter));
@@ -224,12 +227,12 @@ class ReportServiceTest {
 
 			// when & then
 			assertThatThrownBy(() -> reportService.createReport(reporter.getId(), request))
-				.isInstanceOf(BusinessException.class)
+				.isInstanceOf(NotFoundException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
 		}
 
 		@Test
-		@DisplayName("이미 신고한 게시글을 다시 신고하면 BusinessException")
+		@DisplayName("이미 신고한 게시글을 다시 신고하면 BadRequestException")
 		void createReport_duplicate_board_report() {
 			// given
 			given(userRepository.findById(reporter.getId())).willReturn(Optional.of(reporter));
@@ -246,12 +249,12 @@ class ReportServiceTest {
 
 			// when & then
 			assertThatThrownBy(() -> reportService.createReport(reporter.getId(), request))
-				.isInstanceOf(BusinessException.class)
+				.isInstanceOf(BadRequestException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_REPORTED);
 		}
 
 		@Test
-		@DisplayName("이미 신고한 댓글을 다시 신고하면 BusinessException")
+		@DisplayName("이미 신고한 댓글을 다시 신고하면 BadRequestException")
 		void createReport_duplicate_comment_report() {
 			// given
 			given(userRepository.findById(reporter.getId())).willReturn(Optional.of(reporter));
@@ -268,12 +271,12 @@ class ReportServiceTest {
 
 			// when & then
 			assertThatThrownBy(() -> reportService.createReport(reporter.getId(), request))
-				.isInstanceOf(BusinessException.class)
+				.isInstanceOf(BadRequestException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_REPORTED);
 		}
 
 		@Test
-		@DisplayName("댓글ID와 게시글ID가 모두 있으면 BusinessException")
+		@DisplayName("댓글ID와 게시글ID가 모두 있으면 NotFoundException")
 		void createReport_both_ids_present() {
 			// given
 			given(userRepository.findById(reporter.getId())).willReturn(Optional.of(reporter));
@@ -287,12 +290,12 @@ class ReportServiceTest {
 
 			// when & then
 			assertThatThrownBy(() -> reportService.createReport(reporter.getId(), request))
-				.isInstanceOf(BusinessException.class)
+				.isInstanceOf(NotFoundException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
 		}
 
 		@Test
-		@DisplayName("댓글ID와 게시글ID가 모두 없으면 BusinessException")
+		@DisplayName("댓글ID와 게시글ID가 모두 없으면 InvalidValueException")
 		void createReport_no_target_specified() {
 			// given
 			given(userRepository.findById(reporter.getId())).willReturn(Optional.of(reporter));
@@ -304,7 +307,7 @@ class ReportServiceTest {
 
 			// when & then
 			assertThatThrownBy(() -> reportService.createReport(reporter.getId(), request))
-				.isInstanceOf(BusinessException.class)
+				.isInstanceOf(InvalidValueException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FIELD_ERROR);
 		}
 	}
@@ -368,7 +371,7 @@ class ReportServiceTest {
 
 			// when & then
 			assertThatThrownBy(() -> reportService.processReport(99L, report.getId(), request))
-				.isInstanceOf(BusinessException.class)
+				.isInstanceOf(NotFoundException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
 		}
 
@@ -391,7 +394,7 @@ class ReportServiceTest {
 		}
 
 		@Test
-		@DisplayName("신고가 존재하지 않으면 BusinessException")
+		@DisplayName("신고가 존재하지 않으면 NotFoundException")
 		void processReport_report_not_found() {
 			// given
 			given(userRepository.findById(admin.getId())).willReturn(Optional.of(admin));
@@ -405,12 +408,12 @@ class ReportServiceTest {
 
 			// when & then
 			assertThatThrownBy(() -> reportService.processReport(admin.getId(), 999L, request))
-				.isInstanceOf(BusinessException.class)
+				.isInstanceOf(NotFoundException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.REPORT_NOT_FOUND);
 		}
 
 		@Test
-		@DisplayName("이미 처리된 신고를 다시 처리하면 BusinessException")
+		@DisplayName("이미 처리된 신고를 다시 처리하면 BadRequestException")
 		void processReport_already_processed() {
 			// given
 			given(userRepository.findById(admin.getId())).willReturn(Optional.of(admin));
@@ -431,7 +434,7 @@ class ReportServiceTest {
 
 			// when & then
 			assertThatThrownBy(() -> reportService.processReport(admin.getId(), 1L, request))
-				.isInstanceOf(BusinessException.class)
+				.isInstanceOf(BadRequestException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_PROCESSED_REPORT);
 		}
 	}

--- a/src/test/java/com/daruda/darudaserver/domain/user/entity/enums/PositionsTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/user/entity/enums/PositionsTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.daruda.darudaserver.global.error.code.ErrorCode;
-import com.daruda.darudaserver.global.error.exception.BusinessException;
+import com.daruda.darudaserver.global.error.exception.InvalidValueException;
 
 @ExtendWith(MockitoExtension.class)
 class PositionsTest {
@@ -34,7 +34,7 @@ class PositionsTest {
 		String invalidName = "없는값";
 
 		// when & then
-		BusinessException exception = assertThrows(BusinessException.class,
+		InvalidValueException exception = assertThrows(InvalidValueException.class,
 			() -> Positions.fromString(invalidName));
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_FIELD_ERROR);
 	}

--- a/src/test/java/com/daruda/darudaserver/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/user/service/AuthServiceTest.java
@@ -32,7 +32,8 @@ import com.daruda.darudaserver.domain.user.entity.enums.SocialType;
 import com.daruda.darudaserver.domain.user.repository.UserRepository;
 import com.daruda.darudaserver.global.auth.jwt.service.TokenService;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
-import com.daruda.darudaserver.global.error.exception.BusinessException;
+import com.daruda.darudaserver.global.error.exception.ConflictException;
+import com.daruda.darudaserver.global.error.exception.NotFoundException;
 
 @ExtendWith(MockitoExtension.class)
 public class AuthServiceTest {
@@ -108,7 +109,7 @@ public class AuthServiceTest {
 		when(userRepository.existsByEmail(email)).thenReturn(true);
 
 		// when
-		BusinessException exception = assertThrows(BusinessException.class,
+		ConflictException exception = assertThrows(ConflictException.class,
 			() -> authService.register(email, nickname, positionStr));
 
 		// then
@@ -231,7 +232,7 @@ public class AuthServiceTest {
 
 		// when
 		when(userRepository.findById(userId)).thenReturn(Optional.empty());
-		BusinessException exception = assertThrows(BusinessException.class,
+		NotFoundException exception = assertThrows(NotFoundException.class,
 			() -> authService.withdraw(userId));
 
 		// then

--- a/src/test/java/com/daruda/darudaserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/user/service/UserServiceTest.java
@@ -27,7 +27,9 @@ import com.daruda.darudaserver.domain.user.entity.User;
 import com.daruda.darudaserver.domain.user.entity.enums.Positions;
 import com.daruda.darudaserver.domain.user.repository.UserRepository;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
+import com.daruda.darudaserver.global.error.exception.BadRequestException;
 import com.daruda.darudaserver.global.error.exception.BusinessException;
+import com.daruda.darudaserver.global.error.exception.ConflictException;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,7 +59,20 @@ class UserServiceTest {
 
 		// then
 		assertTrue(result);
-		verify(userRepository).existsByNickname(nickname);
+	}
+
+	@Test
+	@DisplayName("닉네임 중복 확인 - 중복되지 않은 경우")
+	void isDuplicatedNickname_notDuplicated() {
+		// given
+		String nickname = "tester";
+		when(userRepository.existsByNickname(nickname)).thenReturn(false);
+
+		// when
+		boolean result = userService.isDuplicatedNickname(nickname);
+
+		// then
+		assertFalse(result);
 	}
 
 	@Test
@@ -76,7 +91,6 @@ class UserServiceTest {
 		MyProfileResponse response = userService.getMyProfile(userId);
 
 		// then
-		assertNotNull(response);
 		assertEquals(nickname, response.nickname());
 		assertEquals(positions, response.positions());
 	}
@@ -88,42 +102,35 @@ class UserServiceTest {
 		Long userId = 1L;
 		when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-		// when
-		when(userRepository.findById(userId)).thenReturn(Optional.empty());
+		// when & then
 		NotFoundException exception = assertThrows(NotFoundException.class, () -> userService.getMyProfile(userId));
-
-		// then
 		assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
 	}
 
 	@Test
-	@DisplayName("찜한 도구 목록 조회 성공")
+	@DisplayName("좋아하는 툴 목록 조회 성공")
 	void getFavoriteTools_success() {
 		// given
 		Long userId = 1L;
 		String email = "test@example.com";
 		String nickname = "tester";
 		Positions positions = Positions.STUDENT;
-		PlanType planType = PlanType.FREE;
 		User userEntity = User.of(email, nickname, positions);
+
 		Tool tool = Tool.builder()
-			.toolMainName("toolName")
-			.toolSubName("toolSubName")
-			.category(Category.ALL)
-			.toolLink("toolLink")
-			.description("toolDescription")
+			.toolMainName("tool1")
+			.toolLogo("logo1")
+			.description("desc1")
 			.license(License.FREE)
-			.supportKorea(true)
-			.detailDescription("toolDetailDescription")
-			.planLink("toolPlanLink")
-			.toolLogo("toolLogo")
-			.planType(planType)
+			.category(Category.AI)
 			.build();
+
 		ToolScrap toolScrap = ToolScrap.of(userEntity, tool);
 
 		when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
 		when(toolScrapRepository.findAllByUserId(userId)).thenReturn(List.of(toolScrap));
-		when(toolService.convertToKeywordRes(tool)).thenReturn(List.of("keyword"));
+		when(toolScrapRepository.findByUserAndTool(userEntity, tool)).thenReturn(Optional.of(toolScrap));
+		when(toolService.convertToKeywordRes(tool)).thenReturn(List.of());
 
 		// when
 		FavoriteToolsResponse response = userService.getFavoriteTools(userId);
@@ -134,39 +141,15 @@ class UserServiceTest {
 	}
 
 	@Test
-	@DisplayName("프로필 업데이트 성공 - 닉네임과 포지션 모두 변경")
-	void updateProfile_success() {
+	@DisplayName("프로필 업데이트 성공 - 닉네임만 변경")
+	void updateProfile_onlyNickname() {
 		// given
 		Long userId = 1L;
 		String email = "test@example.com";
-		String nickname = "tester";
-		Positions positions = Positions.STUDENT;
+		String oldNickname = "tester";
 		String newNickname = "newTester";
-		Positions newPositions = Positions.NORMAL;
-		User userEntity = User.of(email, nickname, positions);
-
-		when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
-		when(userRepository.existsByNickname(newNickname)).thenReturn(false);
-
-		// when
-		UpdateMyResponse response = userService.updateProfile(userId, newNickname, Positions.NORMAL.getName());
-
-		// then
-		assertNotNull(response);
-		assertEquals(newNickname, response.nickname());
-		assertEquals(newPositions, response.positions());
-	}
-
-	@Test
-	@DisplayName("프로필 업데이트 성공 - 닉네임 변경")
-	void updateProfile_nickname_success() {
-		// given
-		Long userId = 1L;
-		String email = "test@example.com";
-		String nickname = "tester";
 		Positions positions = Positions.STUDENT;
-		String newNickname = "newTester";
-		User userEntity = User.of(email, nickname, positions);
+		User userEntity = User.of(email, oldNickname, positions);
 
 		when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
 		when(userRepository.existsByNickname(newNickname)).thenReturn(false);
@@ -175,20 +158,20 @@ class UserServiceTest {
 		UpdateMyResponse response = userService.updateProfile(userId, newNickname, null);
 
 		// then
-		assertNotNull(response);
 		assertEquals(newNickname, response.nickname());
+		assertEquals(positions, response.positions());
 	}
 
 	@Test
-	@DisplayName("프로필 업데이트 성공 - 포지션 변경")
-	void updateProfile_position_success() {
+	@DisplayName("프로필 업데이트 성공 - 직무만 변경")
+	void updateProfile_onlyPosition() {
 		// given
 		Long userId = 1L;
 		String email = "test@example.com";
 		String nickname = "tester";
-		Positions positions = Positions.STUDENT;
-		Positions newPositions = Positions.NORMAL;
-		User userEntity = User.of(email, nickname, positions);
+		Positions oldPositions = Positions.STUDENT;
+		Positions newPositions = Positions.WORKER;
+		User userEntity = User.of(email, nickname, oldPositions);
 
 		when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
 
@@ -196,7 +179,30 @@ class UserServiceTest {
 		UpdateMyResponse response = userService.updateProfile(userId, null, newPositions.getName());
 
 		// then
-		assertNotNull(response);
+		assertEquals(nickname, response.nickname());
+		assertEquals(newPositions, response.positions());
+	}
+
+	@Test
+	@DisplayName("프로필 업데이트 성공 - 닉네임과 직무 모두 변경")
+	void updateProfile_bothNicknameAndPosition() {
+		// given
+		Long userId = 1L;
+		String email = "test@example.com";
+		String oldNickname = "tester";
+		String newNickname = "newTester";
+		Positions oldPositions = Positions.STUDENT;
+		Positions newPositions = Positions.WORKER;
+		User userEntity = User.of(email, oldNickname, oldPositions);
+
+		when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+		when(userRepository.existsByNickname(newNickname)).thenReturn(false);
+
+		// when
+		UpdateMyResponse response = userService.updateProfile(userId, newNickname, newPositions.getName());
+
+		// then
+		assertEquals(newNickname, response.nickname());
 		assertEquals(newPositions, response.positions());
 	}
 
@@ -207,7 +213,7 @@ class UserServiceTest {
 		Long userId = 1L;
 
 		// when
-		BusinessException exception = assertThrows(BusinessException.class,
+		BadRequestException exception = assertThrows(BadRequestException.class,
 			() -> userService.updateProfile(userId, null, null));
 
 		// then
@@ -224,7 +230,7 @@ class UserServiceTest {
 
 		// when
 		when(userRepository.findById(userId)).thenReturn(Optional.empty());
-		BusinessException exception = assertThrows(BusinessException.class,
+		NotFoundException exception = assertThrows(NotFoundException.class,
 			() -> userService.updateProfile(userId, nickname, positionStr));
 
 		// then
@@ -245,7 +251,7 @@ class UserServiceTest {
 		when(userRepository.existsByNickname(nickname)).thenReturn(true);
 
 		// when
-		BusinessException exception = assertThrows(BusinessException.class,
+		ConflictException exception = assertThrows(ConflictException.class,
 			() -> userService.updateProfile(userId, nickname, positions.getName()));
 
 		// then


### PR DESCRIPTION
## 📣 Related Issue

- close #382

## 📝 Summary

프로젝트 전반에서 비표준 자바 예외(`IllegalArgumentException` 등)와 `BusinessException` 직접 사용을 지양하고, 각 `ErrorCode`의 HTTP 상태에 맞는 구체적인 서브클래스(`NotFoundException`, `BadRequestException`, `ConflictException`, `ForbiddenException`, `UnauthorizedException`, `InvalidValueException`)로 전면 통일했습니다.

1. **`ConflictException` (409 Conflict용) 신규 추가**
   - `DUPLICATED_NICKNAME`, `DUPLICATED_EMAIL` 등 409 Conflict 계열 예외에 적용
2. **`IllegalArgumentException` 제거 및 서브클래스 교체**
   - `AdminService.updateTool()`: `NotFoundException(ErrorCode.TOOL_NOT_FOUND)`
   - `PlanType.formString()`: `NotFoundException(ErrorCode.DATA_NOT_FOUND)`
   - `UserAuthentication.createUserAuthentication()`: `UnauthorizedException(ErrorCode.EMPTY_OR_INVALID_TOKEN)`
3. **`BusinessException` 직접 던지던 비즈니스 로직 서브클래스로 통일**
   - `ReportService`: `NotFoundException`, `InvalidValueException`, `BadRequestException`
   - `UserService`: `NotFoundException`, `BadRequestException`, `ConflictException`
   - `AuthService`: `ConflictException`, `InvalidValueException`
   - `KakaoService`: `UnauthorizedException`
   - `ImageService`: `InvalidValueException`
   - `Positions`, `BlockDurationInDay`, `SuspensionDuration`: `InvalidValueException`
4. **테스트 코드 단언 및 예외 타입 매칭**
   - `ReportServiceTest`, `UserServiceTest`, `AuthServiceTest`, `PositionsTest` 등 업데이트

## 🙏 Question & PR point

- 비즈니스 예외 발생 시 일관된 HTTP 상태 코드 및 `ErrorCode` 기반 JSON 응답(`ErrorResponse`) 반환
- `check-all.sh` (EditorConfig, Checkstyle, 전체 테스트 156개) 검증 통과

## 📬 Postman

예외 응답 포맷 표준화 (해당 없음)