### PR TITLE
#381 [Docs] 지침 문서에서 완료된 레거시 정리 항목 삭제 및 최신화

### DIFF
--- a/.claude/skills/architecture/references/transaction.md
+++ b/.claude/skills/architecture/references/transaction.md
@@ -52,7 +52,7 @@ public class BoardService {
 2. If it uses `TxType`·`rollbackOn`, it needs **manual mapping** to Spring's `propagation`·`rollbackFor`. Do not convert mechanically.
 3. If it is at the class level, swapping the import still leaves every method as a write transaction. You only gain something once you also reposition `readOnly = true`.
 
-When you find a jakarta import in new or changed code, **flag it.** When you find it in existing code, classify it not as Critical but as **cleanup work** (see the `legacy-cleanup` skill for the current state).
+When you find a jakarta import in new or changed code, **flag it.** (All existing codebase files have been unified to Spring's `@Transactional`).
 
 ## Common misconceptions when diagnosing
 

--- a/.claude/skills/architecture/references/web-layer.md
+++ b/.claude/skills/architecture/references/web-layer.md
@@ -96,5 +96,3 @@ return ResponseEntity.status(HttpStatus.CREATED)
 ```
 
 **Always keep the `SuccessCode`'s status and the actual HTTP response status in sync.** For the error response format and `ErrorCode`-addition rules, see the `error-handling` skill.
-
-> `ApiResponse` is legacy. Do not use it in new code (see the `legacy-cleanup` skill).

--- a/.claude/skills/error-handling/SKILL.md
+++ b/.claude/skills/error-handling/SKILL.md
@@ -72,8 +72,6 @@ BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "E404006", "게시글이 존재하지 않�
 grep -o '"E[0-9]\{6\}"' src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java | sort | uniq -d
 ```
 
-> Some code values are currently duplicated and a typo constant remains. Take care that new code does not reference these (see the `legacy-cleanup` skill for the current state).
-
 ## SuccessCode
 
 Defines the HTTP status + message of success responses (`global/error/code/SuccessCode.java`).

--- a/.claude/skills/legacy-cleanup/SKILL.md
+++ b/.claude/skills/legacy-cleanup/SKILL.md
@@ -11,24 +11,10 @@ This is code written before the guidelines were unified. **New code follows the 
 
 | Item | Current state | Goal |
 |------|---------------|------|
-| Dual response wrappers | `ApiResponse` (7 controllers) / `SuccessResponse` (4) coexist | Unify to `SuccessResponse`, then delete `ApiResponse` |
-| Abbreviated DTO suffixes | `ToolDetailGetRes`, `CategoryRes`, `BoardRes`, etc. (`dto/res`, `dto/req` packages) | `XxxResponse`/`XxxRequest` + `dto/response`, `dto/request` |
-| Entity suffix | `CommentEntity`, `UserEntity`, `NotificationEntity`, `ReportEntity` | `Comment`, `User`, `Notification`, `Report` |
-| Transaction import | **17 files** importing `jakarta.transaction.Transactional` — 12 repositories with `@Modifying` + 5 services (`UserService`, `CommentService`, `AuthService`, `NotificationService`, `TokenService`). All **31 annotation declarations** in these files are bare, attribute-less annotations, so swapping the import alone keeps behavior identical | `org.springframework.transaction.annotation.Transactional` |
-| Transaction scope | Class-level `@Transactional` (write) in 23 places. Of these, `UserService`·`CommentService` also overlap with a jakarta import, so swapping the import alone still leaves reads as write transactions | Class `readOnly = true` + `@Transactional` on write methods only |
-| ErrorCode duplicates | Code values `E400009`·`E400012`·`E400013` are duplicated; the typo constant `REFREH_TOKEN_EMPTY_ERROR` duplicates `REFRESH_TOKEN_EMPTY_ERROR` | Make code values unique + remove the typo constant |
-| HTTP status mismatch | `ResponseEntity.ok()` + `SuccessCode.SUCCESS_CREATE(201)` → body says 201, actual response is 200 | Creation APIs use `status(HttpStatus.CREATED)` |
-| Soft-delete columns | `is_deleted` (comment) / `del_yn` (board) / hard delete (ToolLike) mixed | Unify column name·strategy |
-| Unused code | `S3Service` (actually uses `OciService`), `ApiResponse.ofFailure` | Delete |
-| QueryDSL location | `BoardService` uses `JPAQueryFactory` directly | Split into a custom repository (`BoardRepositoryCustom`) |
-| `BaseTimeEntity` type | `java.sql.Timestamp` | `LocalDateTime` |
-
-## Caution when cleaning up transaction imports
-
-Do not do a mechanical bulk replacement. The order of handling and the exact facts are owned by `architecture` → `references/transaction.md` ("Order of handling when found in existing code") — read them there instead of relying on a copy.
+| Soft-delete columns | `is_deleted` (comment/user) / `del_yn` (board/tool_scrap/tool_like) mixed | Unify column name·strategy (deferred due to no DB migration tooling) |
 
 ## Scope rules for cleanup work
 
 - Handle one item at a time; don't mix several items into one PR.
 - Cleanup must be behavior-preserving. (The `refactor` commit type is owned by `git-convention`, and the full check by `/run-checks` — those are procedure, not rules restated here.)
-- Wide renames (entity suffix, DTO abbreviation) have references spread across the codebase, so rename via the IDE, then run the full check before opening the PR.
+- Wide renames have references spread across the codebase, so rename via the IDE, then run the full check before opening the PR.


### PR DESCRIPTION
## 📣 Related Issue

- close #381

## 📝 Summary

최근 진행된 리팩터링 및 컨벤션 통일을 통해 이미 해결 완료된 레거시 항목들을 프로젝트 지침 문서에서 삭제하고 최신 상태로 갱신했습니다.

- `.claude/skills/legacy-cleanup/SKILL.md`: 완료된 10개 레거시 항목(이중 응답 래퍼 `ApiResponse`, DTO 약어 접미사, Entity 접미사, 트랜잭션 import/scope, ErrorCode 중복, HTTP 상태코드 불일치, 미사용 코드, QueryDSL 위치, `BaseTimeEntity` `LocalDateTime` 전환 등) 삭제
- `.claude/skills/error-handling/SKILL.md`: ErrorCode 중복값 관련 과거 참고 문구 삭제
- `.claude/skills/architecture/references/web-layer.md`: `ApiResponse` 레거시 참고 문구 삭제
- `.claude/skills/architecture/references/transaction.md`: `jakarta.transaction` import 전면 교체 완료 상태 반영

## 🙏 Question & PR point

- 지침 문서 최신화 작업으로 비즈니스 로직 및 API 스펙 변화 없음
- `check-all.sh` 전체 검증 통과

## 📬 Postman

문서 최신화 작업 (해당 없음)
